### PR TITLE
fix: correctly send back the motd from server

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,9 +1,13 @@
 name: Go
 
-on: [push, pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [master]
+    tags: ['*']
 
 jobs:
-
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -91,7 +90,11 @@ func New() *cobra.Command {
 			s.WriteTimeout = time.Minute
 			s.ReadTimeout = time.Minute
 
-			return s.Run(context.Background())
+			err = s.Listen()
+			if err != nil {
+				return err
+			}
+			return s.Run()
 		},
 	}
 	flags := c.Flags()

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,0 +1,156 @@
+package server
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ustclug/rsync-proxy/test/fake/rsync"
+)
+
+func startServer(t *testing.T) *Server {
+	srv := New()
+	const (
+		addr    = "127.0.0.1:0"
+		timeout = time.Second
+	)
+	srv.WebListenAddr = addr
+	srv.ListenAddr = addr
+	srv.ReadTimeout = timeout
+	srv.WriteTimeout = timeout
+	err := srv.Listen()
+	require.NoErrorf(t, err, "Fail to listen")
+
+	go func() {
+		t.Logf("rsync-proxy is running on: %s", srv.TCPListener.Addr())
+		err := srv.Run()
+		assert.NoErrorf(t, err, "Fail to run server")
+	}()
+	return srv
+}
+
+func doClientHandshake(conn *rsync.Conn, version []byte, module string) (svrVersion string, err error) {
+	_, err = conn.Write(version)
+	if err != nil {
+		return
+	}
+
+	svrVersion, err = conn.ReadLine()
+	if err != nil {
+		return
+	}
+
+	_, err = conn.Write([]byte(module + "\n"))
+	return
+}
+
+func doServerHandshake(conn *rsync.Conn, data []byte) (cliVersion, module string, err error) {
+	// read protocol version from client
+	cliVersion, err = conn.ReadLine()
+	if err != nil {
+		return
+	}
+
+	_, err = conn.Write(data)
+	if err != nil {
+		return
+	}
+
+	// read module name from client
+	module, err = conn.ReadLine()
+	return
+}
+
+// See also: https://github.com/ustclug/rsync-proxy/issues/11
+func TestMotdFromServer(t *testing.T) {
+	srv := startServer(t)
+	defer srv.Close()
+	proxyMotd := "Hello\n"
+	srv.Motd = proxyMotd
+
+	l := strings.Repeat("a", TCPBufferSize)
+	serverMotd := fmt.Sprintf("%s\n%s\n\n", l, l)
+
+	fakeRsync := rsync.NewServer(func(conn *rsync.Conn) {
+		defer conn.Close()
+
+		_, _, err := doServerHandshake(conn, append(RsyncdServerVersion, []byte(serverMotd)...))
+		if err != nil {
+			t.Errorf("server handshake: %v", err)
+		}
+	})
+	fakeRsync.Start()
+	defer fakeRsync.Close()
+
+	srv.modules = map[string]string{
+		"fake": fakeRsync.Listener.Addr().String(),
+	}
+
+	r := require.New(t)
+
+	rawConn, err := net.Dial("tcp", srv.TCPListener.Addr().String())
+	r.NoError(err)
+	conn := rsync.NewConn(rawConn)
+	defer conn.Close()
+
+	_, err = doClientHandshake(conn, RsyncdServerVersion, "fake")
+	r.NoError(err)
+
+	allData, err := io.ReadAll(conn)
+	r.NoError(err)
+
+	r.Equal(proxyMotd+"\n"+serverMotd, string(allData))
+}
+
+// See also: https://github.com/ustclug/rsync-proxy/commit/d581c18dab8008c5bc9c1a5d667b49d67a4edfed
+func TestClientReadTimeout(t *testing.T) {
+	srv := startServer(t)
+	defer srv.Close()
+
+	fakeRsync := rsync.NewServer(func(conn *rsync.Conn) {
+		defer conn.Close()
+
+		_, _, err := doServerHandshake(conn, RsyncdServerVersion)
+		if err != nil {
+			t.Errorf("server handshake: %v", err)
+			return
+		}
+
+		for i := 0; i < 3; i++ {
+			_, err = conn.Write([]byte("data\n"))
+			if err != nil {
+				t.Errorf("write data: %v", err)
+				return
+			}
+			time.Sleep(srv.ReadTimeout)
+		}
+	})
+	fakeRsync.Start()
+	defer fakeRsync.Close()
+
+	srv.modules = map[string]string{
+		"fake": fakeRsync.Listener.Addr().String(),
+	}
+
+	r := require.New(t)
+
+	rawConn, err := net.Dial("tcp", srv.TCPListener.Addr().String())
+	r.NoError(err)
+	conn := rsync.NewConn(rawConn)
+	defer conn.Close()
+
+	_, err = doClientHandshake(conn, RsyncdServerVersion, "fake")
+	r.NoError(err)
+
+	allData, err := io.ReadAll(conn)
+	r.NoError(err)
+
+	expected := strings.Repeat("data\n", 3)
+	r.Equal(expected, string(allData))
+}

--- a/pkg/server/utils.go
+++ b/pkg/server/utils.go
@@ -13,10 +13,8 @@ func writeWithTimeout(conn net.Conn, buf []byte, timeout time.Duration) (n int, 
 	return
 }
 
+// readLine will read as much as it can until the last read character is a newline character.
 func readLine(conn net.Conn, buf []byte, timeout time.Duration) (n int, err error) {
-	// 这个只是特殊场景下的 readLine
-	// rsync 在握手过程中除了 protocol version 跟 module name 以外并不会传输其他数据，而这些数据又是以 '\n' 分割
-	// 所以可以直接尽力读满传进来的 buffer 直到读到 '\n' 为止
 	max := len(buf)
 	for {
 		if timeout > 0 {

--- a/test/fake/rsync/conn.go
+++ b/test/fake/rsync/conn.go
@@ -1,0 +1,34 @@
+package rsync
+
+import (
+	"bufio"
+	"net"
+)
+
+type Conn struct {
+	br   *bufio.Reader
+	conn net.Conn
+}
+
+func (c *Conn) Read(b []byte) (int, error) {
+	return c.br.Read(b)
+}
+
+func (c *Conn) Write(b []byte) (int, error) {
+	return c.conn.Write(b)
+}
+
+func (c *Conn) ReadLine() (string, error) {
+	return c.br.ReadString('\n')
+}
+
+func (c *Conn) Close() error {
+	return c.conn.Close()
+}
+
+func NewConn(c net.Conn) *Conn {
+	return &Conn{
+		br:   bufio.NewReader(c),
+		conn: c,
+	}
+}

--- a/test/fake/rsync/server.go
+++ b/test/fake/rsync/server.go
@@ -1,0 +1,45 @@
+package rsync
+
+import (
+	"errors"
+	"fmt"
+	"net"
+)
+
+type Server struct {
+	handler func(conn *Conn)
+
+	Listener net.Listener
+}
+
+func NewServer(handler func(conn *Conn)) *Server {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		panic(fmt.Sprintf("fakersyncd: fail to listen: %v", err))
+	}
+	return &Server{
+		handler:  handler,
+		Listener: l,
+	}
+}
+
+func (r *Server) Start() {
+	go r.handleConn()
+}
+
+func (r *Server) handleConn() {
+	for {
+		c, err := r.Listener.Accept()
+		if err != nil {
+			if !errors.Is(err, net.ErrClosed) {
+				panic(fmt.Sprintf("fakersyncd: fail to accept connection: %v", err))
+			}
+			return
+		}
+		go r.handler(NewConn(c))
+	}
+}
+
+func (r *Server) Close() {
+	_ = r.Listener.Close()
+}


### PR DESCRIPTION
Fixes #11

1. Check the remaining data after reading protocol version from upstream and send them back to the client if there is any
2. Add new method `Listen` and `Close` to `Server` to make writing tests easier
3. Add some regression tests