### PR TITLE
Reply with @ERROR on unknown module so clients exit non-zero

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -542,8 +542,14 @@ func (s *Server) relay(ctx context.Context, index uint32, downConn net.Conn) err
 
 	targets, ok := s.getTargetsForModule(moduleName)
 	if !ok {
-		_, _ = writeWithTimeout(downConn, fmt.Appendf(nil, "unknown module: %s\n", moduleName), writeTimeout)
-		_, _ = writeWithTimeout(downConn, RsyncdExit, writeTimeout)
+		// Use the rsyncd "@ERROR:" wire format so that the rsync
+		// client treats this as a fatal protocol error and exits with
+		// a non-zero status (RERR_FERROR_XFER, exit 5), matching the
+		// behavior of a real rsyncd. Sending only "unknown module:
+		// ...\n" followed by "@RSYNCD: EXIT" caused the client to
+		// exit 0, which masked the failure for downstream tools such
+		// as tunasync (which then marked the job as success).
+		_, _ = writeWithTimeout(downConn, fmt.Appendf(nil, "@ERROR: Unknown module '%s'\n", moduleName), writeTimeout)
 		s.accessLog.F("client %s requests non-existing module %s", ip, moduleName)
 		return nil
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -129,6 +129,38 @@ func TestMotdFromServer(t *testing.T) {
 	r.Equal(proxyMotd+"\n"+serverMotd, string(allData))
 }
 
+// TestUnknownModuleSendsErrorPrefix verifies that requesting a module that
+// the proxy is not configured to serve makes the proxy reply with an
+// "@ERROR:" line, matching real rsyncd's wire format. The rsync client
+// treats an "@ERROR:" reply as a fatal protocol error and exits 5,
+// while a plain message followed by "@RSYNCD: EXIT" causes the client
+// to exit 0, which historically masked configuration breakage in tools
+// such as tunasync.
+func TestUnknownModuleSendsErrorPrefix(t *testing.T) {
+	srv := startServer(t)
+	defer srv.Close()
+
+	srv.modules = map[string][]Target{}
+	srv.upstreamQueues = map[string]*queue.Queue{}
+
+	r := require.New(t)
+
+	rawConn, err := net.Dial("tcp", srv.TCPListener.Addr().String())
+	r.NoError(err)
+	conn := rsync.NewConn(rawConn)
+	defer conn.Close()
+
+	_, err = doClientHandshake(conn, RsyncdServerVersion, "does-not-exist")
+	r.NoError(err)
+
+	allData, err := io.ReadAll(conn)
+	r.NoError(err)
+
+	r.Contains(string(allData), "@ERROR:", "proxy should reply with @ERROR: prefix so client exits non-zero")
+	r.Contains(string(allData), "does-not-exist")
+	r.NotContains(string(allData), "@RSYNCD: EXIT", "should not send EXIT after @ERROR; rsync client must treat the response as fatal")
+}
+
 // See also: https://github.com/ustclug/rsync-proxy/commit/d581c18dab8008c5bc9c1a5d667b49d67a4edfed
 func TestClientReadTimeout(t *testing.T) {
 	srv := startServer(t)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -246,4 +247,28 @@ func TestDiscoverModulesFromUpstream(t *testing.T) {
 	}
 
 	r.Equal("bar\nbaz\nfoo\n", string(outputBytes))
+}
+
+// TestUnknownModuleExitCode verifies that a real rsync client exits with
+// a non-zero status when it requests a module that the proxy does not
+// know about. This is a regression test for an earlier behavior where
+// the proxy emitted "unknown module: <name>\n@RSYNCD: EXIT\n", which
+// rsync interprets as a normal end-of-listing (exit 0). The fix makes
+// the proxy emit "@ERROR:" instead, matching real rsyncd; rsync then
+// treats it as a fatal protocol error and exits with code 5
+// (RERR_FERROR_XFER).
+func TestUnknownModuleExitCode(t *testing.T) {
+	proxy := startProxy(t)
+
+	r := require.New(t)
+
+	cmd := newRsyncCommand(getRsyncPath(proxy, "/does-not-exist/"))
+	out, err := cmd.CombinedOutput()
+	r.Error(err, "rsync should fail when module does not exist; got output: %s", out)
+
+	exitErr, ok := err.(*exec.ExitError)
+	r.True(ok, "expected *exec.ExitError, got %T: %v", err, err)
+	r.NotEqual(0, exitErr.ExitCode(), "rsync should exit non-zero on unknown module; output: %s", out)
+	r.Contains(string(out), "@ERROR", "rsync should report the @ERROR line; output: %s", out)
+	r.Contains(string(out), "does-not-exist", "rsync should report the module name; output: %s", out)
 }


### PR DESCRIPTION
## Problem

When a client requests a module that the proxy is not configured to serve, `rsync-proxy` currently writes:

```
unknown module: <name>
@RSYNCD: EXIT
```

A real `rsyncd` answers the same situation with:

```
@ERROR: Unknown module '<name>'
```

Rsync's client treats `@RSYNCD: EXIT` as a normal end-of-listing and exits **0**, while it treats an `@ERROR:` line as a fatal protocol error and exits **5** (`RERR_FERROR_XFER`). The current proxy reply therefore looks like a successful no-op to anything that checks rsync's exit code.

## Impact

This silently broke long-running mirrors. Concrete example: NJU's `loongnix` mirror runs daily against `rsync://rsync.mirrors.ustc.edu.cn/loongnix/`. USTC retired that module roughly 10 months ago, so the proxy began returning `unknown module: loongnix`, but tunasync kept marking each run as `success` because rsync exited 0. Local data sat at the July 2024 snapshot for the better part of a year while the dashboard stayed green.

You can reproduce the difference today against any healthy upstream:

```sh
$ rsync rsync://mirrors.tuna.tsinghua.edu.cn/does-not-exist/  # real rsyncd
... motd ...
$ echo $?
5

$ rsync rsync://rsync.mirrors.ustc.edu.cn/does-not-exist/     # rsync-proxy
Served by rsync-proxy (https://github.com/ustclug/rsync-proxy)

unknown module: does-not-exist
$ echo $?
0
```

The wire capture (via `nc`) confirms the proxy is sending plain text rather than `@ERROR:`:

```
@RSYNCD: 32.0 sha512 sha256 sha1 md5 md4
Served by rsync-proxy (https://github.com/ustclug/rsync-proxy)

unknown module: does-not-exist
@RSYNCD: EXIT
```

The relevant rsync source (`clientserver.c`):

```c
if (strncmp(line, "@ERROR", 6) == 0) {
    rprintf(FERROR, "%s\n", line);
    return -1;            // becomes exit code 5
}
```

```c
if (!lp_list(i))
    io_printf(f_out, "@ERROR: Unknown module '%s'\n", name);
```

## Fix

Drop the trailing `@RSYNCD: EXIT` and prefix the message with `@ERROR:` so the wire format matches `rsyncd`. The client closes the connection on its own and exits with a non-zero status. The format string mirrors rsyncd's exactly (`@ERROR: Unknown module '<name>'`).

## Tests

- `pkg/server`: `TestUnknownModuleSendsErrorPrefix` asserts the proxy emits `@ERROR:` and does **not** emit `@RSYNCD: EXIT` for an unknown module. Verified red/green by reverting the fix locally — the test fails on the old behavior.
- `test/e2e`: `TestUnknownModuleExitCode` drives a real `rsync` binary at the proxy, asserts `cmd.Run()` returns a non-zero `*exec.ExitError`, and that the captured output contains `@ERROR` and the requested module name. Both new tests pass under `go test -race ./...` together with the existing suite.

No behavior change for known modules, and no protocol/version bump.

