### PR TITLE
release: fix version ldflags package path

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -s -w -X github.com/ustclug/rsync-proxy/pkg/info.Version={{.Version}} -X github.com/ustclug/rsync-proxy/pkg/info.BuildDate={{.Date}} -X github.com/ustclug/rsync-proxy/pkg/info.GitCommit={{.Commit}}
+      - -s -w -X github.com/ustclug/rsync-proxy/cmd.Version={{.Version}} -X github.com/ustclug/rsync-proxy/cmd.BuildDate={{.Date}} -X github.com/ustclug/rsync-proxy/cmd.GitCommit={{.Commit}}
 archives:
   - formats: binary
     name_template: "{{ .Binary }}_{{ .Os  }}_{{ .Arch }}"


### PR DESCRIPTION
## Summary

The `.goreleaser.yml` ldflags line targets `github.com/ustclug/rsync-proxy/pkg/info.{Version,BuildDate,GitCommit}`, but no such package exists. The actual variables live in the `cmd` package (`cmd/cmd.go`):

```go
var (
    Version   = "0.0.0"
    GitCommit = "$Format:%H$"
    BuildDate = "1970-01-01T00:00:00Z"
)
```

Go's linker silently ignores `-X` for unresolved symbols, so the released binary keeps the source defaults.

## Reproduction

The `v0.1.4` release binary:

```
$ rsync-proxy_linux_amd64 version
{"GitCommit":"$Format:%H$","BuildDate":"1970-01-01T00:00:00Z","Version":"0.0.0",...}
```

## Fix

Update the package path in `.goreleaser.yml` to match the variable locations and the existing `Makefile` (which uses `github.com/ustclug/rsync-proxy/cmd.Version`).

## Verification

Local build with the corrected ldflags reports the injected values correctly.