### PR TITLE
refactor: unify upstream label to use config name

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -90,7 +90,7 @@ func SendConnectionsRequest(addr string, stdout, stderr io.Writer) error {
 			Index         int       `json:"index"`
 			RemoteAddr    string    `json:"remote"`
 			Module        string    `json:"module"`
-			UpstreamAddr  string    `json:"upstream"`
+			Upstream      string    `json:"upstream"`
 			ConnectedAt   time.Time `json:"connected"`
 			ReceivedBytes int64     `json:"receivedBytes"`
 			SentBytes     int64     `json:"sentBytes"`
@@ -125,7 +125,7 @@ func SendConnectionsRequest(addr string, stdout, stderr io.Writer) error {
 			tw.AlignRight,   // Index
 			tw.AlignRight,   // RemoteAddr
 			tw.AlignDefault, // Module
-			tw.AlignRight,   // UpstreamAddr
+			tw.AlignDefault, // Upstream
 			tw.AlignDefault, // ConnectedAt
 			tw.AlignRight,   // ReceivedBytes
 			tw.AlignRight,   // SentBytes
@@ -137,7 +137,7 @@ func SendConnectionsRequest(addr string, stdout, stderr io.Writer) error {
 			strconv.Itoa(conn.Index),
 			conn.RemoteAddr,
 			conn.Module,
-			conn.UpstreamAddr,
+			conn.Upstream,
 			conn.ConnectedAt.Format(time.DateTime),
 			strconv.FormatInt(conn.ReceivedBytes, 10),
 			strconv.FormatInt(conn.SentBytes, 10),

--- a/pkg/server/metrics.go
+++ b/pkg/server/metrics.go
@@ -110,7 +110,7 @@ func (s *Server) writePrometheusMetrics(w io.Writer, now time.Time) {
 		snapshot := conn.snapshot()
 		key := prometheusConnectionGroup{
 			module:   prometheusLabelValueOrUnknown(snapshot.Module),
-			upstream: prometheusLabelValueOrUnknown(snapshot.UpstreamAddr),
+			upstream: prometheusLabelValueOrUnknown(snapshot.Upstream),
 		}
 		connectionCounts[key]++
 	}
@@ -138,21 +138,21 @@ func (s *Server) writePrometheusMetrics(w io.Writer, now time.Time) {
 	_, _ = fmt.Fprintln(w, "# TYPE rsync_proxy_connection_sent_bytes gauge")
 	for _, conn := range connections {
 		snapshot := conn.snapshot()
-		_, _ = fmt.Fprintf(w, "rsync_proxy_connection_sent_bytes{%s} %d\n", prometheusLabels(snapshot.Index, snapshot.Module, snapshot.UpstreamAddr), snapshot.SentBytes)
+		_, _ = fmt.Fprintf(w, "rsync_proxy_connection_sent_bytes{%s} %d\n", prometheusLabels(snapshot.Index, snapshot.Module, snapshot.Upstream), snapshot.SentBytes)
 	}
 
 	_, _ = fmt.Fprintln(w, "# HELP rsync_proxy_connection_received_bytes Bytes received from clients for active connections.")
 	_, _ = fmt.Fprintln(w, "# TYPE rsync_proxy_connection_received_bytes gauge")
 	for _, conn := range connections {
 		snapshot := conn.snapshot()
-		_, _ = fmt.Fprintf(w, "rsync_proxy_connection_received_bytes{%s} %d\n", prometheusLabels(snapshot.Index, snapshot.Module, snapshot.UpstreamAddr), snapshot.ReceivedBytes)
+		_, _ = fmt.Fprintf(w, "rsync_proxy_connection_received_bytes{%s} %d\n", prometheusLabels(snapshot.Index, snapshot.Module, snapshot.Upstream), snapshot.ReceivedBytes)
 	}
 
 	_, _ = fmt.Fprintln(w, "# HELP rsync_proxy_connection_connected_timestamp_seconds Unix timestamp when active connections were established.")
 	_, _ = fmt.Fprintln(w, "# TYPE rsync_proxy_connection_connected_timestamp_seconds gauge")
 	for _, conn := range connections {
 		snapshot := conn.snapshot()
-		_, _ = fmt.Fprintf(w, "rsync_proxy_connection_connected_timestamp_seconds{%s} %d\n", prometheusLabels(snapshot.Index, snapshot.Module, snapshot.UpstreamAddr), snapshot.ConnectedAt.Unix())
+		_, _ = fmt.Fprintf(w, "rsync_proxy_connection_connected_timestamp_seconds{%s} %d\n", prometheusLabels(snapshot.Index, snapshot.Module, snapshot.Upstream), snapshot.ConnectedAt.Unix())
 	}
 
 	_, _ = fmt.Fprintln(w, "# HELP rsync_proxy_connection_duration_seconds Current duration of active connections.")
@@ -163,7 +163,7 @@ func (s *Server) writePrometheusMetrics(w io.Writer, now time.Time) {
 		if duration < 0 {
 			duration = 0
 		}
-		_, _ = fmt.Fprintf(w, "rsync_proxy_connection_duration_seconds{%s} %.3f\n", prometheusLabels(snapshot.Index, snapshot.Module, snapshot.UpstreamAddr), duration)
+		_, _ = fmt.Fprintf(w, "rsync_proxy_connection_duration_seconds{%s} %.3f\n", prometheusLabels(snapshot.Index, snapshot.Module, snapshot.Upstream), duration)
 	}
 
 	_, _ = fmt.Fprintln(w, "# HELP rsync_proxy_accepted_connections_total Total accepted connections since start.")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -59,7 +59,7 @@ type ConnInfo struct {
 	RemoteAddr    string
 	ConnectedAt   time.Time
 	Module        string
-	UpstreamAddr  string
+	Upstream      string
 	SentBytes     atomic.Int64
 	ReceivedBytes atomic.Int64
 }
@@ -70,7 +70,7 @@ type connInfoSnapshot struct {
 	RemoteAddr    string    `json:"remote"`
 	ConnectedAt   time.Time `json:"connected"`
 	Module        string    `json:"module"`
-	UpstreamAddr  string    `json:"upstream"`
+	Upstream      string    `json:"upstream"`
 	SentBytes     int64     `json:"sentBytes"`
 	ReceivedBytes int64     `json:"receivedBytes"`
 }
@@ -81,10 +81,10 @@ func (c *ConnInfo) SetModule(module string) {
 	c.Module = module
 }
 
-func (c *ConnInfo) SetUpstreamAddr(upstreamAddr string) {
+func (c *ConnInfo) SetUpstream(upstream string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.UpstreamAddr = upstreamAddr
+	c.Upstream = upstream
 }
 
 func (c *ConnInfo) snapshot() connInfoSnapshot {
@@ -96,7 +96,7 @@ func (c *ConnInfo) snapshot() connInfoSnapshot {
 		RemoteAddr:    c.RemoteAddr,
 		ConnectedAt:   c.ConnectedAt,
 		Module:        c.Module,
-		UpstreamAddr:  c.UpstreamAddr,
+		Upstream:      c.Upstream,
 		SentBytes:     c.SentBytes.Load(),
 		ReceivedBytes: c.ReceivedBytes.Load(),
 	}
@@ -606,7 +606,7 @@ func (s *Server) relay(ctx context.Context, index uint32, downConn net.Conn) err
 	target := targets[chooseTargetByClientIP(net.ParseIP(ip), len(targets))]
 	upstreamAddr := target.Addr
 	useProxyProtocol := target.UseProxyProtocol
-	info.SetUpstreamAddr(upstreamAddr)
+	info.SetUpstream(target.Upstream)
 
 	upstreamQueue, ok := s.getQueueForUpstream(target.Upstream)
 	if !ok {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -375,7 +375,7 @@ func TestStatusIncludesSelectedUpstream(t *testing.T) {
 		if len(infos) != 1 {
 			return false
 		}
-		return infos[0].snapshot().UpstreamAddr == upstreamAddr
+		return infos[0].snapshot().Upstream == "u1"
 	}, time.Second, 10*time.Millisecond)
 
 	wg.Done()
@@ -445,7 +445,7 @@ func TestMetricsIncludesActiveConnections(t *testing.T) {
 		if len(infos) != 1 {
 			return false
 		}
-		return infos[0].snapshot().UpstreamAddr == upstreamAddr
+		return infos[0].snapshot().Upstream == "u1"
 	}, time.Second, 10*time.Millisecond)
 
 	resp, err := testHTTPClient().Get("http://" + srv.HTTPListener.Addr().String() + "/metrics")
@@ -458,14 +458,15 @@ func TestMetricsIncludesActiveConnections(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Contains(t, text, "rsync_proxy_active_connections 1\n")
-	assert.Contains(t, text, fmt.Sprintf("rsync_proxy_active_connections_by_module{module=\"fake\",upstream=%q} 1\n", upstreamAddr))
+	assert.Contains(t, text, "rsync_proxy_active_connections_by_module{module=\"fake\",upstream=\"u1\"} 1\n")
 	assert.Contains(t, text, "rsync_proxy_connection_sent_bytes{index=\"")
 	assert.Contains(t, text, "module=\"fake\"")
-	assert.Contains(t, text, fmt.Sprintf("upstream=%q", upstreamAddr))
+	assert.Contains(t, text, "upstream=\"u1\"")
 	assert.Contains(t, text, "rsync_proxy_connection_received_bytes{index=\"")
 	assert.Contains(t, text, "rsync_proxy_connection_connected_timestamp_seconds{index=\"")
 	assert.Contains(t, text, "rsync_proxy_connection_duration_seconds{index=\"")
 	assert.NotContains(t, text, rawConn.LocalAddr().String())
+	assert.NotContains(t, text, upstreamAddr)
 
 	wg.Done()
 }
@@ -655,12 +656,12 @@ func TestPrometheusConnectionGroupingUsesStructuredKey(t *testing.T) {
 
 	first := &ConnInfo{Index: 1, ConnectedAt: time.Unix(100, 0)}
 	first.Module = "a\xffb"
-	first.UpstreamAddr = "c"
+	first.Upstream = "c"
 	srv.connInfo.Store(first.Index, first)
 
 	second := &ConnInfo{Index: 2, ConnectedAt: time.Unix(100, 0)}
 	second.Module = "a"
-	second.UpstreamAddr = "b\xffc"
+	second.Upstream = "b\xffc"
 	srv.connInfo.Store(second.Index, second)
 
 	var buf bytes.Buffer
@@ -676,7 +677,7 @@ func TestPrometheusDurationIncludesFractionalSeconds(t *testing.T) {
 	srv := New()
 	conn := &ConnInfo{Index: 1, ConnectedAt: time.Unix(100, 0)}
 	conn.Module = "fake"
-	conn.UpstreamAddr = "127.0.0.1:873"
+	conn.Upstream = "127.0.0.1:873"
 	srv.connInfo.Store(conn.Index, conn)
 
 	var buf bytes.Buffer


### PR DESCRIPTION
## Background

When PR #34 was merged it added queue/upstream-level Prometheus metrics
that label connections by **upstream config name** (the `Name` of the
`[upstreams.<NAME>]` table), while the older per-connection metrics
added in PR #30 already labeled connections by the resolved **upstream
address** (`<host>:<port>` from `target.Addr`, plus `"unknown"`).

Both sets of series share the same label key `upstream` but their values
have completely different semantics, so dashboards cannot
`on(upstream)` join the two groups, and the same `upstream` value can
mean different things in different panels.

PR #30 only landed in the v0.1.4 → v0.1.5 cycle (no broad public
adoption yet), so cleaning this up now still has a low blast radius.

## Change

Switch the per-connection metrics to use the upstream's **config name**
as well, matching the queue/upstream metrics introduced in PR #34.

Affected metrics (label `upstream` value changes from
`<addr>` / `"unknown"` to the upstream's config Name):

- `rsync_proxy_active_connections_by_module`
- `rsync_proxy_connection_sent_bytes`
- `rsync_proxy_connection_received_bytes`
- `rsync_proxy_connection_connected_timestamp_seconds`
- `rsync_proxy_connection_duration_seconds`

The JSON tag on `ConnInfo.Upstream` is still `"upstream"` so the
`/connections` debug endpoint output keeps the same key for clients.

## Why config name

1. The config name is a stable logical identifier; the resolved address
   is an implementation detail that can shift on each pick.
2. When an upstream has multiple backends, aggregating by Name answers
   the natural question "how much traffic did this upstream handle?".
3. PR #34 already chose the Name route. Unifying lets dashboards join
   per-connection and queue metrics on `upstream`.

## Compatibility

This is a breaking change for anyone querying the per-connection
metrics by upstream **address** in dashboards/alerts. Series with
addresses will stop receiving data and new series with the upstream's
config Name will appear instead.

Given PR #30 only shipped in v0.1.5 and the metrics are intended for
operator dashboards (not external integrations), changing them now is
safer than leaving the inconsistency in place.

## Tests

- `go vet ./... && go build ./... && go test -race ./pkg/...` — all green.
- `TestStatusIncludesSelectedUpstream` and
  `TestMetricsIncludesActiveConnections` updated to assert the config
  Name; the latter also gained a `assert.NotContains` for the old address.
