### PR TITLE
feat: add per-module lifetime counters for connections and bytes

### DIFF
--- a/pkg/server/metrics.go
+++ b/pkg/server/metrics.go
@@ -181,4 +181,58 @@ func (s *Server) writePrometheusMetrics(w io.Writer, now time.Time) {
 	_, _ = fmt.Fprintln(w, "# HELP rsync_proxy_received_bytes_total Total bytes received from clients since start.")
 	_, _ = fmt.Fprintln(w, "# TYPE rsync_proxy_received_bytes_total counter")
 	_, _ = fmt.Fprintf(w, "rsync_proxy_received_bytes_total %d\n", s.recvBytesTotal.Load())
+
+	// Per-(module, upstream) lifetime counters. We collect a sorted slice of
+	// keys so that the text output is stable across scrapes.
+	type moduleStat struct {
+		key       moduleUpstreamKey
+		completed uint64
+		sentBytes uint64
+		recvBytes uint64
+	}
+	var moduleStats []moduleStat
+	s.moduleCounters.Range(func(k, v any) bool {
+		key := k.(moduleUpstreamKey)
+		c := v.(*moduleCounters)
+		moduleStats = append(moduleStats, moduleStat{
+			key:       key,
+			completed: c.completed.Load(),
+			sentBytes: c.sentBytes.Load(),
+			recvBytes: c.recvBytes.Load(),
+		})
+		return true
+	})
+	sort.Slice(moduleStats, func(i, j int) bool {
+		if moduleStats[i].key.module != moduleStats[j].key.module {
+			return moduleStats[i].key.module < moduleStats[j].key.module
+		}
+		return moduleStats[i].key.upstream < moduleStats[j].key.upstream
+	})
+
+	_, _ = fmt.Fprintln(w, "# HELP rsync_proxy_module_completed_connections_total Total completed connections by module and upstream.")
+	_, _ = fmt.Fprintln(w, "# TYPE rsync_proxy_module_completed_connections_total counter")
+	for _, m := range moduleStats {
+		_, _ = fmt.Fprintf(w, "rsync_proxy_module_completed_connections_total{module=\"%s\",upstream=\"%s\"} %d\n",
+			prometheusEscapeLabelValue(prometheusLabelValueOrUnknown(m.key.module)),
+			prometheusEscapeLabelValue(prometheusLabelValueOrUnknown(m.key.upstream)),
+			m.completed)
+	}
+
+	_, _ = fmt.Fprintln(w, "# HELP rsync_proxy_module_sent_bytes_total Total bytes sent to clients by module and upstream.")
+	_, _ = fmt.Fprintln(w, "# TYPE rsync_proxy_module_sent_bytes_total counter")
+	for _, m := range moduleStats {
+		_, _ = fmt.Fprintf(w, "rsync_proxy_module_sent_bytes_total{module=\"%s\",upstream=\"%s\"} %d\n",
+			prometheusEscapeLabelValue(prometheusLabelValueOrUnknown(m.key.module)),
+			prometheusEscapeLabelValue(prometheusLabelValueOrUnknown(m.key.upstream)),
+			m.sentBytes)
+	}
+
+	_, _ = fmt.Fprintln(w, "# HELP rsync_proxy_module_received_bytes_total Total bytes received from clients by module and upstream.")
+	_, _ = fmt.Fprintln(w, "# TYPE rsync_proxy_module_received_bytes_total counter")
+	for _, m := range moduleStats {
+		_, _ = fmt.Fprintf(w, "rsync_proxy_module_received_bytes_total{module=\"%s\",upstream=\"%s\"} %d\n",
+			prometheusEscapeLabelValue(prometheusLabelValueOrUnknown(m.key.module)),
+			prometheusEscapeLabelValue(prometheusLabelValueOrUnknown(m.key.upstream)),
+			m.recvBytes)
+	}
 }

--- a/pkg/server/metrics.go
+++ b/pkg/server/metrics.go
@@ -213,8 +213,8 @@ func (s *Server) writePrometheusMetrics(w io.Writer, now time.Time) {
 	_, _ = fmt.Fprintln(w, "# TYPE rsync_proxy_module_completed_connections_total counter")
 	for _, m := range moduleStats {
 		_, _ = fmt.Fprintf(w, "rsync_proxy_module_completed_connections_total{module=\"%s\",upstream=\"%s\"} %d\n",
-			prometheusEscapeLabelValue(prometheusLabelValueOrUnknown(m.key.module)),
-			prometheusEscapeLabelValue(prometheusLabelValueOrUnknown(m.key.upstream)),
+			prometheusEscapeLabelValue(m.key.module),
+			prometheusEscapeLabelValue(m.key.upstream),
 			m.completed)
 	}
 
@@ -222,8 +222,8 @@ func (s *Server) writePrometheusMetrics(w io.Writer, now time.Time) {
 	_, _ = fmt.Fprintln(w, "# TYPE rsync_proxy_module_sent_bytes_total counter")
 	for _, m := range moduleStats {
 		_, _ = fmt.Fprintf(w, "rsync_proxy_module_sent_bytes_total{module=\"%s\",upstream=\"%s\"} %d\n",
-			prometheusEscapeLabelValue(prometheusLabelValueOrUnknown(m.key.module)),
-			prometheusEscapeLabelValue(prometheusLabelValueOrUnknown(m.key.upstream)),
+			prometheusEscapeLabelValue(m.key.module),
+			prometheusEscapeLabelValue(m.key.upstream),
 			m.sentBytes)
 	}
 
@@ -231,8 +231,8 @@ func (s *Server) writePrometheusMetrics(w io.Writer, now time.Time) {
 	_, _ = fmt.Fprintln(w, "# TYPE rsync_proxy_module_received_bytes_total counter")
 	for _, m := range moduleStats {
 		_, _ = fmt.Fprintf(w, "rsync_proxy_module_received_bytes_total{module=\"%s\",upstream=\"%s\"} %d\n",
-			prometheusEscapeLabelValue(prometheusLabelValueOrUnknown(m.key.module)),
-			prometheusEscapeLabelValue(prometheusLabelValueOrUnknown(m.key.upstream)),
+			prometheusEscapeLabelValue(m.key.module),
+			prometheusEscapeLabelValue(m.key.upstream),
 			m.recvBytes)
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -127,6 +127,21 @@ type upstreamCounters struct {
 	dialError atomic.Uint64
 }
 
+// moduleUpstreamKey identifies a (module, upstream) pair for per-module
+// lifetime counters.
+type moduleUpstreamKey struct {
+	module   string
+	upstream string
+}
+
+// moduleCounters holds per-(module, upstream) lifetime counters that are
+// updated when a relay finishes successfully.
+type moduleCounters struct {
+	completed atomic.Uint64
+	sentBytes atomic.Uint64
+	recvBytes atomic.Uint64
+}
+
 type Server struct {
 	// --- Options section
 	// Listen Address
@@ -165,6 +180,11 @@ type Server struct {
 	// map key is upstream name. Value is *upstreamCounters.
 	upstreamCounters   sync.Map
 	unknownModuleCount atomic.Uint64
+
+	// Per-(module, upstream) counters tracked when a relay finishes
+	// successfully. Lazy-initialized via getModuleCounters.
+	// map key is moduleUpstreamKey. Value is *moduleCounters.
+	moduleCounters sync.Map
 
 	TCPListener  net.Listener
 	TLSListener  net.Listener
@@ -344,6 +364,17 @@ func (s *Server) getUpstreamCounters(name string) *upstreamCounters {
 	}
 	v, _ := s.upstreamCounters.LoadOrStore(name, &upstreamCounters{})
 	return v.(*upstreamCounters)
+}
+
+// getModuleCounters returns the per-(module, upstream) counters, creating
+// them lazily on first reference. Safe for concurrent use.
+func (s *Server) getModuleCounters(module, upstream string) *moduleCounters {
+	key := moduleUpstreamKey{module: module, upstream: upstream}
+	if v, ok := s.moduleCounters.Load(key); ok {
+		return v.(*moduleCounters)
+	}
+	v, _ := s.moduleCounters.LoadOrStore(key, &moduleCounters{})
+	return v.(*moduleCounters)
 }
 
 func buildModuleTargets(upstreams []upstreamConfig) map[string][]Target {
@@ -743,6 +774,11 @@ func (s *Server) relay(ctx context.Context, index uint32, downConn net.Conn) err
 	s.completedConnCount.Add(1)
 	s.sentBytesTotal.Add(uint64(sentBytes))
 	s.recvBytesTotal.Add(uint64(receivedBytes))
+
+	mc := s.getModuleCounters(moduleName, target.Upstream)
+	mc.completed.Add(1)
+	mc.sentBytes.Add(uint64(sentBytes))
+	mc.recvBytes.Add(uint64(receivedBytes))
 
 	duration := time.Since(info.ConnectedAt)
 	s.accessLog.F("client %s finishes module %s (sent: %d, received: %d, duration: %s)", ip, moduleName, sentBytes, receivedBytes, duration)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -368,8 +368,17 @@ func (s *Server) getUpstreamCounters(name string) *upstreamCounters {
 
 // getModuleCounters returns the per-(module, upstream) counters, creating
 // them lazily on first reference. Safe for concurrent use.
+//
+// Empty module/upstream values are normalized to "unknown" so that the
+// internal sync.Map key matches what prometheusLabelValueOrUnknown emits at
+// scrape time. Otherwise an empty string and the literal "unknown" would
+// produce two distinct map entries that render to the same Prometheus label
+// set, leading to duplicate output lines.
 func (s *Server) getModuleCounters(module, upstream string) *moduleCounters {
-	key := moduleUpstreamKey{module: module, upstream: upstream}
+	key := moduleUpstreamKey{
+		module:   prometheusLabelValueOrUnknown(module),
+		upstream: prometheusLabelValueOrUnknown(upstream),
+	}
 	if v, ok := s.moduleCounters.Load(key); ok {
 		return v.(*moduleCounters)
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1112,3 +1112,27 @@ func TestDiscoverModulesFromTrailingModuleBlock(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"bar", "foo"}, modules)
 }
+
+func TestModuleCountersNormalizeEmptyKeyToUnknown(t *testing.T) {
+	srv := New()
+
+	// Both empty and "unknown" inputs must point at the same internal
+	// counter, so a scrape cannot emit two lines that share the same
+	// rendered Prometheus label set.
+	c1 := srv.getModuleCounters("", "")
+	c2 := srv.getModuleCounters("unknown", "unknown")
+	assert.Same(t, c1, c2)
+
+	c1.completed.Add(7)
+
+	// metrics.go uses prometheusEscapeLabelValue on the stored key only,
+	// so the rendered output must show the normalized "unknown" value.
+	var buf bytes.Buffer
+	srv.writePrometheusMetrics(&buf, time.Now())
+	text := buf.String()
+	assert.Contains(t, text, "rsync_proxy_module_completed_connections_total{module=\"unknown\",upstream=\"unknown\"} 7\n")
+
+	// And there should be exactly one such line — i.e. no second line with
+	// an empty-string label rendered separately.
+	assert.Equal(t, 1, strings.Count(text, "rsync_proxy_module_completed_connections_total{"))
+}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -742,6 +742,17 @@ func TestMetricsIncludesLifetimeCounters(t *testing.T) {
 	assert.Contains(t, text, fmt.Sprintf("rsync_proxy_sent_bytes_total %d\n", len(payload)))
 	assert.Contains(t, text, "# HELP rsync_proxy_received_bytes_total")
 	assert.Contains(t, text, "# TYPE rsync_proxy_received_bytes_total counter")
+
+	// Per-(module, upstream) lifetime counters.
+	assert.Contains(t, text, "# HELP rsync_proxy_module_completed_connections_total")
+	assert.Contains(t, text, "# TYPE rsync_proxy_module_completed_connections_total counter")
+	assert.Contains(t, text, "rsync_proxy_module_completed_connections_total{module=\"fake\",upstream=\"u1\"} 1\n")
+	assert.Contains(t, text, "# HELP rsync_proxy_module_sent_bytes_total")
+	assert.Contains(t, text, "# TYPE rsync_proxy_module_sent_bytes_total counter")
+	assert.Contains(t, text, fmt.Sprintf("rsync_proxy_module_sent_bytes_total{module=\"fake\",upstream=\"u1\"} %d\n", len(payload)))
+	assert.Contains(t, text, "# HELP rsync_proxy_module_received_bytes_total")
+	assert.Contains(t, text, "# TYPE rsync_proxy_module_received_bytes_total counter")
+	assert.Contains(t, text, "rsync_proxy_module_received_bytes_total{module=\"fake\",upstream=\"u1\"} 0\n")
 }
 
 func TestPrometheusLabelValueEscaping(t *testing.T) {


### PR DESCRIPTION
## Background

Today the proxy already exposes lifetime counters
(`rsync_proxy_completed_connections_total`,
`rsync_proxy_sent_bytes_total`, `rsync_proxy_received_bytes_total`)
without any labels, plus per-connection gauges with `module` and
`upstream` labels.

That makes some dashboards awkward:

- The unlabeled lifetime counters can't tell which module is generating
  traffic over time.
- The per-connection gauges (`rsync_proxy_connection_sent_bytes` etc.)
  cannot be used to compute historical traffic per module — the series
  disappear when the connection ends, so `rate()` / `increase()` give
  bogus results.

Operators end up wanting "Top modules by traffic over the last 24h" but
the metrics surface doesn't really support that.

## Change

Introduce three new Prometheus counters incremented at relay
completion, labeled by `module` and `upstream`:

- `rsync_proxy_module_completed_connections_total{module,upstream}`
- `rsync_proxy_module_sent_bytes_total{module,upstream}`
- `rsync_proxy_module_received_bytes_total{module,upstream}`

The counters are increased at the same point as the existing global
totals, so they only count successful relays — the listing-all-modules,
unknown-module, queue-full and dial-error paths are intentionally
excluded, matching the existing
`rsync_proxy_completed_connections_total` semantics.

Accepted is *not* split per module because the module name isn't
known yet at accept time.

## Implementation

- Storage: `sync.Map` keyed by `(module, upstream)`. Entries are created
  lazily on the first finished relay for that pair.
- Output is sorted by `(module, upstream)` so scrapes are stable.
- `target.Upstream` is the upstream's config Name.

## Tests

- `go vet ./... && go build ./... && go test -race ./pkg/...` — green.
- `TestMetricsIncludesLifetimeCounters` extended to assert the new
  counters with their labels.

## Operational note

These are pure additions — no existing series are renamed or removed.
