### PR TITLE
feat: add connection lifecycle protections (idle/max-duration/throughput floor, per-IP cap, TCP keepalive, dial timeout)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,15 @@ cp logrotate.conf /etc/logrotate.d/
 ```shell
 cp fail2ban/filter.d/* /etc/fail2ban/filter.d/
 ```
+
+# 配置
+
+除了基本的监听地址、TLS、access/error log 等，rsync-proxy 还提供了一组连接保护与限流相关的配置项，全部默认关闭、可以按需启用，包括：relay 阶段的 idle 超时与最大持续时长、TCP keepalive 周期、单 IP 对单上游的并发连接数上限、上游拨号超时、relay 阶段的吞吐率下限（带 grace 期，避免误伤大 module 的 file-list 阶段）。各上游还可以独立配置最大并发与排队上限，并支持 PROXY protocol。
+
+完整字段含义、推荐起点值与公共 mirror 的取值依据，见 [`assets/config.example.toml`](assets/config.example.toml)。
+
+# 监控
+
+rsync-proxy 在 `listen_http` 上暴露 Prometheus 格式的 `/metrics` 端点，覆盖连接生命周期、按 module/upstream 的累计流量、排队与失败计数、各类终止原因（idle/max-duration/throughput-floor/per-IP），以及 Go runtime 指标。
+
+仓库 [`grafana/dashboard.json`](grafana/dashboard.json) 提供了一份现成的 Grafana dashboard，对应上述指标。

--- a/README.md
+++ b/README.md
@@ -63,9 +63,53 @@ cp fail2ban/filter.d/* /etc/fail2ban/filter.d/
 
 # 配置
 
-除了基本的监听地址、TLS、access/error log 等，rsync-proxy 还提供了一组连接保护与限流相关的配置项，全部默认关闭、可以按需启用，包括：relay 阶段的 idle 超时与最大持续时长、TCP keepalive 周期、单 IP 对单上游的并发连接数上限、上游拨号超时、relay 阶段的吞吐率下限（带 grace 期，避免误伤大 module 的 file-list 阶段）。各上游还可以独立配置最大并发与排队上限，并支持 PROXY protocol。
+配置文件采用 TOML 格式，分为两段：`[proxy]` 段是 rsync-proxy 自身的设置，`[upstreams.<NAME>]` 段为每个上游 rsync daemon 一项。完整示例见 [`assets/config.example.toml`](assets/config.example.toml)。
 
-完整字段含义、推荐起点值与公共 mirror 的取值依据，见 [`assets/config.example.toml`](assets/config.example.toml)。
+## `[proxy]` 基础
+
+| 字段 | 类型 | 默认 | 说明 |
+| --- | --- | --- | --- |
+| `listen` | string | — | 明文 rsync 监听地址，如 `"0.0.0.0:873"`。 |
+| `listen_tls` | string | — | TLS rsync 监听地址，可选。设置后会与 `listen` 共存。 |
+| `listen_http` | string | — | 控制面 HTTP 监听地址，可为 `host:port` 或 unix socket 路径。`/metrics`（Prometheus）、`/reload`、`/status` 由此暴露。 |
+| `tls_cert_file` | string | — | TLS 证书文件，配 `listen_tls` 使用。reload 时自动重读。 |
+| `tls_key_file` | string | — | TLS 私钥文件。reload 时自动重读。 |
+| `access_log` | string | stdout | 访问日志路径。 |
+| `error_log` | string | stderr | 错误日志路径。 |
+| `motd` | string | 空 | 客户端连接成功后展示的一行欢迎信息。 |
+
+注：`listen`、`listen_tls`、`listen_http` 在 reload 时不会更新，需重启进程。
+
+## `[proxy]` 连接保护与限流
+
+下列字段全部默认为 `0`（关闭），按需启用。完整含义、推荐起点值与取舍在 [`assets/config.example.toml`](assets/config.example.toml) 中有详细注释。
+
+| 字段 | 类型 | 默认 | 含义 | 公共 mirror 推荐起点 |
+| --- | --- | --- | --- | --- |
+| `relay_idle_timeout` | int 秒 | 0 | relay 阶段双向无 I/O 多久后关闭连接。语义同 rsyncd `timeout`。 | `600` |
+| `relay_max_duration` | int 秒 | 0 | relay 阶段总时长上限。超时关闭，rsync 客户端通常会重连续传。 | `14400`（4h） |
+| `tcp_keepalive` | int 秒 | 0 | 客户端连接和上游连接的 TCP keepalive 周期，0 沿用 OS 默认（通常 ~2h）。 | `120` |
+| `per_ip_max_active_connections` | int | 0 | 单 IP 对单上游最多并发 relay 连接数，proxy-wide 默认值。NAT/校园出口 IP 时取值需放宽。 | `4` |
+| `dial_timeout` | int 秒 | 0 | 拨号上游的超时；0 沿用内核 SYN 重试（~75s）。 | `5`（LAN） |
+| `min_throughput_bytes` | int64 字节 | 0 | relay 阶段最近 `min_throughput_window` 秒内累计收发须 ≥ 此值，否则视作慢速吸血并关闭。0 关闭整组检查。 | `1048576` |
+| `min_throughput_window` | int 秒 | 60 | 上述滑动窗口长度。 | `60` |
+| `min_throughput_grace` | int 秒 | = window | 连接刚开始的豁免期，避免误杀大 module 的 file-list 阶段。 | `600` |
+
+各项触发的事件都有对应的 Prometheus counter（`rsync_proxy_relay_idle_timeout_terminated_total`、`rsync_proxy_relay_max_duration_terminated_total`、`rsync_proxy_throughput_floor_terminated_total`、`rsync_proxy_per_ip_rejected_total`、`rsync_proxy_upstream_dial_errors_total`），便于先观察再调参。
+
+## `[upstreams.<NAME>]`
+
+每个上游一项，名字（`NAME`）任意，仅用于日志与 metric 标签。
+
+| 字段 | 类型 | 默认 | 说明 |
+| --- | --- | --- | --- |
+| `address` | string | — | 上游地址，可为 `host:port` 或 unix socket 路径（如 `/run/rsyncd.sock`，需上游通过 xinetd 或 `systemd.socket Accept=yes` 暴露）。 |
+| `modules` | []string | — | 该上游提供的 module 列表。多个上游声明相同 module 时按客户端 IP 做负载均衡。 |
+| `discover_modules` | bool | false | 启动/reload 时自动从上游拉 module 列表。上游不可达会导致启动失败。与 `modules` 二选一。 |
+| `use_proxy_protocol` | bool | false | 与上游通信时附加 PROXY protocol 头，便于上游记录真实客户端 IP。需上游 rsyncd 启用 PROXY protocol 支持。 |
+| `max_active_connections` | int | 0 | 该上游最大并发 relay 连接数，0 表示不限制。 |
+| `max_queued_connections` | int | 0 | 达到上限后排队的最大长度，0 表示不排队。 |
+| `per_ip_max_active_connections` | int | 0 | 覆盖 `[proxy]` 中的同名值；0 表示继承 proxy-wide 默认。 |
 
 # 监控
 

--- a/README.md
+++ b/README.md
@@ -115,4 +115,4 @@ cp fail2ban/filter.d/* /etc/fail2ban/filter.d/
 
 rsync-proxy 在 `listen_http` 上暴露 Prometheus 格式的 `/metrics` 端点，覆盖连接生命周期、按 module/upstream 的累计流量、排队与失败计数、各类终止原因（idle/max-duration/throughput-floor/per-IP），以及 Go runtime 指标。
 
-仓库 [`grafana/dashboard.json`](grafana/dashboard.json) 提供了一份现成的 Grafana dashboard，对应上述指标。
+仓库 [`contrib/grafana/dashboard.json`](contrib/grafana/dashboard.json) 提供了一份现成的 Grafana dashboard，对应上述指标。

--- a/assets/config.example.toml
+++ b/assets/config.example.toml
@@ -14,48 +14,60 @@ motd = "Served by rsync-proxy (https://github.com/ustclug/rsync-proxy)"
 # Idle timeout (seconds) applied during the bidirectional relay phase
 # of a client connection. If no data flows in either direction for
 # this duration, the connection is terminated. 0 (the default)
-# disables the timeout. This mirrors rsyncd's "timeout" setting in
-# rsyncd.conf(5); 600 is a common choice for public mirrors.
+# disables the timeout, mirroring rsyncd's "timeout = 0" semantics in
+# rsyncd.conf(5). For public mirrors, 600 (10 minutes) is a common
+# starting value.
 #relay_idle_timeout = 0
 
 # Hard upper bound (seconds) on the total wall-clock duration of the
 # bidirectional relay phase. When exceeded the proxy closes the
 # connection regardless of activity. rsync clients typically resume
-# on reconnect. 0 (the default) disables this cap.
+# on reconnect. 0 (the default) disables this cap. For public mirrors,
+# 14400 (4h) bounds the worst case while still accommodating large
+# initial syncs.
 #relay_max_duration = 0
 
 # TCP keepalive period (seconds) applied to accepted client
 # connections and dialed upstream connections. Helps detect
 # half-open connections (peer crashed, NAT entry reaped) within
 # minutes rather than the OS default (~2 hours). 0 (the default)
-# leaves the OS-default keepalive behavior in place.
+# leaves the OS-default keepalive behavior in place. A typical value
+# is 120 (2 minutes).
 #tcp_keepalive = 0
 
 # Default per-IP per-upstream concurrent active connection cap.
 # Limits how many simultaneous active relay connections a single
 # client IP may have to any one upstream, preventing a single client
 # from monopolizing upstream slots. 0 (the default) disables the
-# limit. Each upstream may override this via its own
-# per_ip_max_active_connections setting below.
+# limit. A typical value for public mirrors is 4. Each upstream may
+# override this via its own per_ip_max_active_connections setting
+# below. Be cautious when many legitimate clients share a single
+# egress IP (NAT, campus networks): set the cap large enough to
+# accommodate them.
 #per_ip_max_active_connections = 0
 
 # Connect timeout (seconds) when dialing upstreams. Bounds how long
 # the proxy waits for an unresponsive upstream before failing fast
 # and incrementing rsync_proxy_upstream_dial_errors_total. 0 (the
 # default) leaves the OS connect-attempt behavior in place
-# (typically ~75s of SYN retries on Linux).
+# (typically ~75s of SYN retries on Linux). For LAN upstreams a
+# short value such as 5 fails fast without keeping the slot tied up.
 #dial_timeout = 0
 
 # Throughput floor enforced during the relay phase. A connection
-# that transfers fewer than min_throughput_bytes over the most
-# recent min_throughput_window seconds is treated as slow-leeching
-# and terminated. min_throughput_grace gives a fresh connection
-# this many seconds of ramp-up before the floor is enforced;
-# defaults to min_throughput_window when unset. Set
-# min_throughput_bytes to 0 (the default) to disable the check.
+# that transfers fewer than min_throughput_bytes (counting both
+# directions) over the most recent min_throughput_window seconds is
+# treated as slow-leeching and terminated. min_throughput_grace
+# gives a fresh connection this many seconds of ramp-up before the
+# floor is enforced; this matters because rsync's initial file-list
+# phase can take many minutes for very large modules (millions of
+# files), during which the apparent throughput is low. Defaults to
+# min_throughput_window when unset. Set min_throughput_bytes to 0
+# (the default) to disable the check. Typical starting values:
+# bytes = 1048576 (1 MiB), window = 60, grace = 600.
 #min_throughput_bytes = 0
 #min_throughput_window = 60
-#min_throughput_grace = 60
+#min_throughput_grace = 600
 
 [upstreams.u1]
 address = "127.0.0.1:1234"

--- a/assets/config.example.toml
+++ b/assets/config.example.toml
@@ -11,6 +11,13 @@ tls_key_file = "/etc/rsync-proxy/tls/server.key"
 
 motd = "Served by rsync-proxy (https://github.com/ustclug/rsync-proxy)"
 
+# Idle timeout (seconds) applied during the bidirectional relay phase
+# of a client connection. If no data flows in either direction for
+# this duration, the connection is terminated. 0 (the default)
+# disables the timeout. This mirrors rsyncd's "timeout" setting in
+# rsyncd.conf(5); 600 is a common choice for public mirrors.
+#relay_idle_timeout = 0
+
 [upstreams.u1]
 address = "127.0.0.1:1234"
 modules = ["foo"]

--- a/assets/config.example.toml
+++ b/assets/config.example.toml
@@ -18,11 +18,35 @@ motd = "Served by rsync-proxy (https://github.com/ustclug/rsync-proxy)"
 # rsyncd.conf(5); 600 is a common choice for public mirrors.
 #relay_idle_timeout = 0
 
+# Hard upper bound (seconds) on the total wall-clock duration of the
+# bidirectional relay phase. When exceeded the proxy closes the
+# connection regardless of activity. rsync clients typically resume
+# on reconnect. 0 (the default) disables this cap.
+#relay_max_duration = 0
+
+# TCP keepalive period (seconds) applied to accepted client
+# connections and dialed upstream connections. Helps detect
+# half-open connections (peer crashed, NAT entry reaped) within
+# minutes rather than the OS default (~2 hours). 0 (the default)
+# leaves the OS-default keepalive behavior in place.
+#tcp_keepalive = 0
+
+# Default per-IP per-upstream concurrent active connection cap.
+# Limits how many simultaneous active relay connections a single
+# client IP may have to any one upstream, preventing a single client
+# from monopolizing upstream slots. 0 (the default) disables the
+# limit. Each upstream may override this via its own
+# per_ip_max_active_connections setting below.
+#per_ip_max_active_connections = 0
+
 [upstreams.u1]
 address = "127.0.0.1:1234"
 modules = ["foo"]
 max_active_connections = 60
 max_queued_connections = 60
+# Override the proxy-wide per_ip_max_active_connections for this
+# upstream. 0 means inherit the proxy-wide default.
+#per_ip_max_active_connections = 4
 
 [upstreams.u1_auto]
 address = "127.0.0.1:1234"

--- a/assets/config.example.toml
+++ b/assets/config.example.toml
@@ -39,6 +39,24 @@ motd = "Served by rsync-proxy (https://github.com/ustclug/rsync-proxy)"
 # per_ip_max_active_connections setting below.
 #per_ip_max_active_connections = 0
 
+# Connect timeout (seconds) when dialing upstreams. Bounds how long
+# the proxy waits for an unresponsive upstream before failing fast
+# and incrementing rsync_proxy_upstream_dial_errors_total. 0 (the
+# default) leaves the OS connect-attempt behavior in place
+# (typically ~75s of SYN retries on Linux).
+#dial_timeout = 0
+
+# Throughput floor enforced during the relay phase. A connection
+# that transfers fewer than min_throughput_bytes over the most
+# recent min_throughput_window seconds is treated as slow-leeching
+# and terminated. min_throughput_grace gives a fresh connection
+# this many seconds of ramp-up before the floor is enforced;
+# defaults to min_throughput_window when unset. Set
+# min_throughput_bytes to 0 (the default) to disable the check.
+#min_throughput_bytes = 0
+#min_throughput_window = 60
+#min_throughput_grace = 60
+
 [upstreams.u1]
 address = "127.0.0.1:1234"
 modules = ["foo"]

--- a/contrib/grafana/dashboard.json
+++ b/contrib/grafana/dashboard.json
@@ -68,6 +68,25 @@
   "templating": {
     "list": [
       {
+        "name": "job",
+        "label": "job",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(rsync_proxy_active_connections, job)",
+        "query": {
+          "query": "label_values(rsync_proxy_active_connections, job)",
+          "refId": "Variable"
+        },
+        "refresh": 1,
+        "multi": false,
+        "includeAll": false,
+        "sort": 1,
+        "hide": 0
+      },
+      {
         "name": "instance",
         "label": "instance",
         "type": "query",
@@ -75,14 +94,10 @@
           "type": "prometheus",
           "uid": "${DS_PROMETHEUS}"
         },
-        "definition": "label_values(rsync_proxy_active_connections, instance)",
+        "definition": "label_values(rsync_proxy_active_connections{job=\"$job\"}, instance)",
         "query": {
-          "query": "label_values(rsync_proxy_active_connections, instance)",
+          "query": "label_values(rsync_proxy_active_connections{job=\"$job\"}, instance)",
           "refId": "Variable"
-        },
-        "current": {
-          "text": "mirror.nju.edu.cn:9528",
-          "value": "mirror.nju.edu.cn:9528"
         },
         "refresh": 1,
         "multi": false,
@@ -169,7 +184,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rsync_proxy_active_connections{job=\"ic\",instance=\"$instance\"})",
+          "expr": "sum(rsync_proxy_active_connections{job=\"$job\",instance=\"$instance\"})",
           "refId": "A"
         }
       ]
@@ -234,7 +249,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rsync_proxy_queued_connections{job=\"ic\",instance=\"$instance\"})",
+          "expr": "sum(rsync_proxy_queued_connections{job=\"$job\",instance=\"$instance\"})",
           "refId": "A"
         }
       ]
@@ -292,7 +307,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(rsync_proxy_accepted_connections_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "expr": "sum(rate(rsync_proxy_accepted_connections_total{job=\"$job\",instance=\"$instance\"}[5m]))",
           "refId": "A"
         }
       ]
@@ -350,7 +365,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(rsync_proxy_sent_bytes_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "expr": "sum(rate(rsync_proxy_sent_bytes_total{job=\"$job\",instance=\"$instance\"}[5m]))",
           "refId": "A"
         }
       ]
@@ -408,7 +423,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(rsync_proxy_received_bytes_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "expr": "sum(rate(rsync_proxy_received_bytes_total{job=\"$job\",instance=\"$instance\"}[5m]))",
           "refId": "A"
         }
       ]
@@ -474,7 +489,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(increase(rsync_proxy_queue_full_rejected_total{job=\"ic\",instance=\"$instance\"}[1h])) + sum(increase(rsync_proxy_upstream_dial_errors_total{job=\"ic\",instance=\"$instance\"}[1h])) + sum(increase(rsync_proxy_unknown_module_requests_total{job=\"ic\",instance=\"$instance\"}[1h]))",
+          "expr": "sum(increase(rsync_proxy_queue_full_rejected_total{job=\"$job\",instance=\"$instance\"}[1h])) + sum(increase(rsync_proxy_upstream_dial_errors_total{job=\"$job\",instance=\"$instance\"}[1h])) + sum(increase(rsync_proxy_unknown_module_requests_total{job=\"$job\",instance=\"$instance\"}[1h]))",
           "refId": "A"
         }
       ]
@@ -532,7 +547,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(rsync_proxy_accepted_connections_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "expr": "sum(rate(rsync_proxy_accepted_connections_total{job=\"$job\",instance=\"$instance\"}[5m]))",
           "legendFormat": "accepted",
           "refId": "A"
         },
@@ -541,7 +556,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(rsync_proxy_completed_connections_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "expr": "sum(rate(rsync_proxy_completed_connections_total{job=\"$job\",instance=\"$instance\"}[5m]))",
           "legendFormat": "completed",
           "refId": "B"
         },
@@ -550,7 +565,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(rsync_proxy_queue_full_rejected_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "expr": "sum(rate(rsync_proxy_queue_full_rejected_total{job=\"$job\",instance=\"$instance\"}[5m]))",
           "legendFormat": "rejected (queue full)",
           "refId": "C"
         },
@@ -559,7 +574,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(rsync_proxy_upstream_dial_errors_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "expr": "sum(rate(rsync_proxy_upstream_dial_errors_total{job=\"$job\",instance=\"$instance\"}[5m]))",
           "legendFormat": "upstream dial errors",
           "refId": "D"
         },
@@ -568,7 +583,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(rsync_proxy_unknown_module_requests_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "expr": "sum(rate(rsync_proxy_unknown_module_requests_total{job=\"$job\",instance=\"$instance\"}[5m]))",
           "legendFormat": "unknown module",
           "refId": "E"
         }
@@ -627,7 +642,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(rsync_proxy_sent_bytes_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "expr": "sum(rate(rsync_proxy_sent_bytes_total{job=\"$job\",instance=\"$instance\"}[5m]))",
           "legendFormat": "egress (sent)",
           "refId": "A"
         },
@@ -636,7 +651,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(rsync_proxy_received_bytes_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "expr": "sum(rate(rsync_proxy_received_bytes_total{job=\"$job\",instance=\"$instance\"}[5m]))",
           "legendFormat": "ingress (received)",
           "refId": "B"
         }
@@ -708,7 +723,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "topk(15, sum by (module) (rsync_proxy_active_connections_by_module{job=\"ic\",instance=\"$instance\"}))",
+          "expr": "topk(15, sum by (module) (rsync_proxy_active_connections_by_module{job=\"$job\",instance=\"$instance\"}))",
           "legendFormat": "{{module}}",
           "refId": "A"
         }
@@ -767,7 +782,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum by (upstream) (rsync_proxy_active_connections_by_module{job=\"ic\",instance=\"$instance\"})",
+          "expr": "sum by (upstream) (rsync_proxy_active_connections_by_module{job=\"$job\",instance=\"$instance\"})",
           "legendFormat": "{{upstream}}",
           "refId": "A"
         }
@@ -984,7 +999,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rsync_proxy_queued_connections{job=\"ic\",instance=\"$instance\"}",
+          "expr": "rsync_proxy_queued_connections{job=\"$job\",instance=\"$instance\"}",
           "format": "table",
           "instant": true,
           "refId": "A"
@@ -994,7 +1009,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rsync_proxy_queue_active_max{job=\"ic\",instance=\"$instance\"}",
+          "expr": "rsync_proxy_queue_active_max{job=\"$job\",instance=\"$instance\"}",
           "format": "table",
           "instant": true,
           "refId": "B"
@@ -1004,7 +1019,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rsync_proxy_queue_queued_max{job=\"ic\",instance=\"$instance\"}",
+          "expr": "rsync_proxy_queue_queued_max{job=\"$job\",instance=\"$instance\"}",
           "format": "table",
           "instant": true,
           "refId": "C"
@@ -1014,7 +1029,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rsync_proxy_queued_connections{job=\"ic\",instance=\"$instance\"} / (rsync_proxy_queue_queued_max{job=\"ic\",instance=\"$instance\"} > 0)",
+          "expr": "rsync_proxy_queued_connections{job=\"$job\",instance=\"$instance\"} / (rsync_proxy_queue_queued_max{job=\"$job\",instance=\"$instance\"} > 0)",
           "format": "table",
           "instant": true,
           "refId": "D"
@@ -1024,7 +1039,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "increase(rsync_proxy_queue_full_rejected_total{job=\"ic\",instance=\"$instance\"}[1h])",
+          "expr": "increase(rsync_proxy_queue_full_rejected_total{job=\"$job\",instance=\"$instance\"}[1h])",
           "format": "table",
           "instant": true,
           "refId": "E"
@@ -1034,7 +1049,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "increase(rsync_proxy_upstream_dial_errors_total{job=\"ic\",instance=\"$instance\"}[1h])",
+          "expr": "increase(rsync_proxy_upstream_dial_errors_total{job=\"$job\",instance=\"$instance\"}[1h])",
           "format": "table",
           "instant": true,
           "refId": "F"
@@ -1152,7 +1167,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rsync_proxy_queued_connections{job=\"ic\",instance=\"$instance\"}",
+          "expr": "rsync_proxy_queued_connections{job=\"$job\",instance=\"$instance\"}",
           "legendFormat": "{{upstream}}",
           "refId": "A"
         }
@@ -1224,7 +1239,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "topk(15, sum by (module) (rsync_proxy_active_connections_by_module{job=\"ic\",instance=\"$instance\"}))",
+          "expr": "topk(15, sum by (module) (rsync_proxy_active_connections_by_module{job=\"$job\",instance=\"$instance\"}))",
           "legendFormat": "{{module}}",
           "refId": "A"
         }
@@ -1316,7 +1331,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rsync_proxy_connection_duration_seconds{job=\"ic\",instance=\"$instance\"}",
+          "expr": "rsync_proxy_connection_duration_seconds{job=\"$job\",instance=\"$instance\"}",
           "format": "table",
           "instant": true,
           "refId": "A"
@@ -1326,7 +1341,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rsync_proxy_connection_sent_bytes{job=\"ic\",instance=\"$instance\"}",
+          "expr": "rsync_proxy_connection_sent_bytes{job=\"$job\",instance=\"$instance\"}",
           "format": "table",
           "instant": true,
           "refId": "B"
@@ -1336,7 +1351,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rsync_proxy_connection_received_bytes{job=\"ic\",instance=\"$instance\"}",
+          "expr": "rsync_proxy_connection_received_bytes{job=\"$job\",instance=\"$instance\"}",
           "format": "table",
           "instant": true,
           "refId": "C"
@@ -1451,7 +1466,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "topk(10, sum by (module) (rate(rsync_proxy_module_completed_connections_total{job=\"ic\",instance=\"$instance\"}[5m])))",
+          "expr": "topk(10, sum by (module) (rate(rsync_proxy_module_completed_connections_total{job=\"$job\",instance=\"$instance\"}[5m])))",
           "legendFormat": "{{module}}",
           "refId": "A"
         }
@@ -1505,7 +1520,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "topk(10, sum by (module) (rate(rsync_proxy_module_sent_bytes_total{job=\"ic\",instance=\"$instance\"}[5m])))",
+          "expr": "topk(10, sum by (module) (rate(rsync_proxy_module_sent_bytes_total{job=\"$job\",instance=\"$instance\"}[5m])))",
           "legendFormat": "{{module}}",
           "refId": "A"
         }
@@ -1559,7 +1574,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "topk(10, sum by (module) (rate(rsync_proxy_module_received_bytes_total{job=\"ic\",instance=\"$instance\"}[5m])))",
+          "expr": "topk(10, sum by (module) (rate(rsync_proxy_module_received_bytes_total{job=\"$job\",instance=\"$instance\"}[5m])))",
           "legendFormat": "{{module}}",
           "refId": "A"
         }
@@ -1631,7 +1646,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(rsync_proxy_queue_full_rejected_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "expr": "sum(rate(rsync_proxy_queue_full_rejected_total{job=\"$job\",instance=\"$instance\"}[5m]))",
           "legendFormat": "queue full (rejected)",
           "refId": "A"
         },
@@ -1640,7 +1655,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(rsync_proxy_upstream_dial_errors_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "expr": "sum(rate(rsync_proxy_upstream_dial_errors_total{job=\"$job\",instance=\"$instance\"}[5m]))",
           "legendFormat": "upstream dial errors",
           "refId": "B"
         },
@@ -1649,7 +1664,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(rsync_proxy_unknown_module_requests_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "expr": "sum(rate(rsync_proxy_unknown_module_requests_total{job=\"$job\",instance=\"$instance\"}[5m]))",
           "legendFormat": "unknown module",
           "refId": "C"
         },
@@ -1658,7 +1673,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(rsync_proxy_per_ip_rejected_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "expr": "sum(rate(rsync_proxy_per_ip_rejected_total{job=\"$job\",instance=\"$instance\"}[5m]))",
           "legendFormat": "per-IP cap (rejected)",
           "refId": "D"
         }
@@ -1725,7 +1740,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum by (upstream) (increase(rsync_proxy_queue_full_rejected_total{job=\"ic\",instance=\"$instance\"}[1h])) > 0",
+          "expr": "sum by (upstream) (increase(rsync_proxy_queue_full_rejected_total{job=\"$job\",instance=\"$instance\"}[1h])) > 0",
           "legendFormat": "{{upstream}} (queue full)",
           "refId": "A"
         },
@@ -1734,7 +1749,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum by (upstream) (increase(rsync_proxy_upstream_dial_errors_total{job=\"ic\",instance=\"$instance\"}[1h])) > 0",
+          "expr": "sum by (upstream) (increase(rsync_proxy_upstream_dial_errors_total{job=\"$job\",instance=\"$instance\"}[1h])) > 0",
           "legendFormat": "{{upstream}} (dial err)",
           "refId": "B"
         },
@@ -1743,7 +1758,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(increase(rsync_proxy_unknown_module_requests_total{job=\"ic\",instance=\"$instance\"}[1h])) > 0",
+          "expr": "sum(increase(rsync_proxy_unknown_module_requests_total{job=\"$job\",instance=\"$instance\"}[1h])) > 0",
           "legendFormat": "unknown module",
           "refId": "C"
         },
@@ -1752,7 +1767,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum by (upstream) (increase(rsync_proxy_per_ip_rejected_total{job=\"ic\",instance=\"$instance\"}[1h])) > 0",
+          "expr": "sum by (upstream) (increase(rsync_proxy_per_ip_rejected_total{job=\"$job\",instance=\"$instance\"}[1h])) > 0",
           "legendFormat": "{{upstream}} (per-IP cap)",
           "refId": "D"
         }
@@ -1823,7 +1838,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(rsync_proxy_relay_idle_timeout_terminated_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "expr": "sum(rate(rsync_proxy_relay_idle_timeout_terminated_total{job=\"$job\",instance=\"$instance\"}[5m]))",
           "legendFormat": "idle timeout",
           "refId": "A"
         },
@@ -1832,7 +1847,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(rsync_proxy_relay_max_duration_terminated_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "expr": "sum(rate(rsync_proxy_relay_max_duration_terminated_total{job=\"$job\",instance=\"$instance\"}[5m]))",
           "legendFormat": "max duration",
           "refId": "B"
         },
@@ -1841,7 +1856,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(rate(rsync_proxy_throughput_floor_terminated_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "expr": "sum(rate(rsync_proxy_throughput_floor_terminated_total{job=\"$job\",instance=\"$instance\"}[5m]))",
           "legendFormat": "throughput floor",
           "refId": "C"
         }
@@ -1907,7 +1922,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum(increase(rsync_proxy_relay_idle_timeout_terminated_total{job=\"ic\",instance=\"$instance\"}[1h])) + sum(increase(rsync_proxy_relay_max_duration_terminated_total{job=\"ic\",instance=\"$instance\"}[1h])) + sum(increase(rsync_proxy_throughput_floor_terminated_total{job=\"ic\",instance=\"$instance\"}[1h]))",
+          "expr": "sum(increase(rsync_proxy_relay_idle_timeout_terminated_total{job=\"$job\",instance=\"$instance\"}[1h])) + sum(increase(rsync_proxy_relay_max_duration_terminated_total{job=\"$job\",instance=\"$instance\"}[1h])) + sum(increase(rsync_proxy_throughput_floor_terminated_total{job=\"$job\",instance=\"$instance\"}[1h]))",
           "legendFormat": "",
           "refId": "A"
         }
@@ -1968,7 +1983,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "go_goroutines{job=\"ic\",instance=\"$instance\"}",
+              "expr": "go_goroutines{job=\"$job\",instance=\"$instance\"}",
               "legendFormat": "goroutines",
               "refId": "A"
             }
@@ -2021,7 +2036,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "go_memstats_heap_inuse_bytes{job=\"ic\",instance=\"$instance\"}",
+              "expr": "go_memstats_heap_inuse_bytes{job=\"$job\",instance=\"$instance\"}",
               "legendFormat": "heap inuse",
               "refId": "A"
             },
@@ -2030,7 +2045,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "go_memstats_heap_alloc_bytes{job=\"ic\",instance=\"$instance\"}",
+              "expr": "go_memstats_heap_alloc_bytes{job=\"$job\",instance=\"$instance\"}",
               "legendFormat": "heap alloc",
               "refId": "B"
             },
@@ -2039,7 +2054,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "process_resident_memory_bytes{job=\"ic\",instance=\"$instance\"}",
+              "expr": "process_resident_memory_bytes{job=\"$job\",instance=\"$instance\"}",
               "legendFormat": "RSS",
               "refId": "C"
             }
@@ -2089,7 +2104,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "rate(process_cpu_seconds_total{job=\"ic\",instance=\"$instance\"}[5m])",
+              "expr": "rate(process_cpu_seconds_total{job=\"$job\",instance=\"$instance\"}[5m])",
               "legendFormat": "cpu cores used",
               "refId": "A"
             }
@@ -2142,7 +2157,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "process_open_fds{job=\"ic\",instance=\"$instance\"}",
+              "expr": "process_open_fds{job=\"$job\",instance=\"$instance\"}",
               "legendFormat": "open fds",
               "refId": "A"
             },
@@ -2151,7 +2166,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "process_max_fds{job=\"ic\",instance=\"$instance\"}",
+              "expr": "process_max_fds{job=\"$job\",instance=\"$instance\"}",
               "legendFormat": "max fds",
               "refId": "B"
             }
@@ -2204,7 +2219,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "rate(go_gc_duration_seconds_sum{job=\"ic\",instance=\"$instance\"}[5m]) / clamp_min(rate(go_gc_duration_seconds_count{job=\"ic\",instance=\"$instance\"}[5m]), 1)",
+              "expr": "rate(go_gc_duration_seconds_sum{job=\"$job\",instance=\"$instance\"}[5m]) / clamp_min(rate(go_gc_duration_seconds_count{job=\"$job\",instance=\"$instance\"}[5m]), 1)",
               "legendFormat": "avg pause (5m)",
               "refId": "A"
             },
@@ -2213,7 +2228,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "go_gc_duration_seconds{job=\"ic\",instance=\"$instance\",quantile=\"1.0\"}",
+              "expr": "go_gc_duration_seconds{job=\"$job\",instance=\"$instance\",quantile=\"1.0\"}",
               "legendFormat": "max pause",
               "refId": "B"
             }
@@ -2276,7 +2291,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "time() - process_start_time_seconds{job=\"ic\",instance=\"$instance\"}",
+              "expr": "time() - process_start_time_seconds{job=\"$job\",instance=\"$instance\"}",
               "refId": "A"
             }
           ]
@@ -2330,7 +2345,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "process_start_time_seconds{job=\"ic\",instance=\"$instance\"} * 1000",
+              "expr": "process_start_time_seconds{job=\"$job\",instance=\"$instance\"} * 1000",
               "refId": "A"
             }
           ]
@@ -2394,7 +2409,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "changes(process_start_time_seconds{job=\"ic\",instance=\"$instance\"}[24h])",
+              "expr": "changes(process_start_time_seconds{job=\"$job\",instance=\"$instance\"}[24h])",
               "refId": "A"
             }
           ]
@@ -2448,7 +2463,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "rate(process_network_transmit_bytes_total{job=\"ic\",instance=\"$instance\"}[5m])",
+              "expr": "rate(process_network_transmit_bytes_total{job=\"$job\",instance=\"$instance\"}[5m])",
               "legendFormat": "socket tx",
               "refId": "A"
             },
@@ -2457,7 +2472,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "rate(process_network_receive_bytes_total{job=\"ic\",instance=\"$instance\"}[5m])",
+              "expr": "rate(process_network_receive_bytes_total{job=\"$job\",instance=\"$instance\"}[5m])",
               "legendFormat": "socket rx",
               "refId": "B"
             },
@@ -2466,7 +2481,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "rate(rsync_proxy_sent_bytes_total{job=\"ic\",instance=\"$instance\"}[5m])",
+              "expr": "rate(rsync_proxy_sent_bytes_total{job=\"$job\",instance=\"$instance\"}[5m])",
               "legendFormat": "rsync sent",
               "refId": "C"
             },
@@ -2475,7 +2490,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "rate(rsync_proxy_received_bytes_total{job=\"ic\",instance=\"$instance\"}[5m])",
+              "expr": "rate(rsync_proxy_received_bytes_total{job=\"$job\",instance=\"$instance\"}[5m])",
               "legendFormat": "rsync received",
               "refId": "D"
             }

--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -1,0 +1,2487 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus data source that scrapes rsync-proxy /metrics",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
+    }
+  ],
+  "title": "rsync-proxy",
+  "uid": "rsync-proxy",
+  "tags": [
+    "rsync",
+    "proxy"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 0,
+  "refresh": "30s",
+  "id": null,
+  "editable": true,
+  "graphTooltip": 1,
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "instance",
+        "label": "instance",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(rsync_proxy_active_connections, instance)",
+        "query": {
+          "query": "label_values(rsync_proxy_active_connections, instance)",
+          "refId": "Variable"
+        },
+        "current": {
+          "text": "mirror.nju.edu.cn:9528",
+          "value": "mirror.nju.edu.cn:9528"
+        },
+        "refresh": 1,
+        "multi": false,
+        "includeAll": false,
+        "sort": 1,
+        "hide": 0
+      }
+    ]
+  },
+  "annotations": {
+    "list": []
+  },
+  "panels": [
+    {
+      "id": 100,
+      "type": "row",
+      "title": "Overview",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "id": 1,
+      "title": "Active Connections",
+      "description": "Total currently relayed connections.",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rsync_proxy_active_connections{job=\"ic\",instance=\"$instance\"})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Queued Connections",
+      "description": "Connections currently waiting for an active slot.",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rsync_proxy_queued_connections{job=\"ic\",instance=\"$instance\"})",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Accept Rate",
+      "description": "Incoming connections per second (5m rate).",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "cps",
+          "decimals": 2
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(rsync_proxy_accepted_connections_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Egress (out)",
+      "description": "Bytes sent to clients (5m rate).",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps",
+          "decimals": 1
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(rsync_proxy_sent_bytes_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Ingress (in)",
+      "description": "Bytes received from clients (5m rate).",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps",
+          "decimals": 1
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(rsync_proxy_received_bytes_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Failures (last 1h)",
+      "description": "Sum of queue-full rejects, upstream dial errors, and unknown-module requests in the last hour.",
+      "type": "stat",
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "textMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(increase(rsync_proxy_queue_full_rejected_total{job=\"ic\",instance=\"$instance\"}[1h])) + sum(increase(rsync_proxy_upstream_dial_errors_total{job=\"ic\",instance=\"$instance\"}[1h])) + sum(increase(rsync_proxy_unknown_module_requests_total{job=\"ic\",instance=\"$instance\"}[1h]))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Connection Lifecycle Rate",
+      "description": "Per-second rate of connection events.",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "cps"
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(rsync_proxy_accepted_connections_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "legendFormat": "accepted",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(rsync_proxy_completed_connections_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "legendFormat": "completed",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(rsync_proxy_queue_full_rejected_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "legendFormat": "rejected (queue full)",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(rsync_proxy_upstream_dial_errors_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "legendFormat": "upstream dial errors",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(rsync_proxy_unknown_module_requests_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "legendFormat": "unknown module",
+          "refId": "E"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Bandwidth",
+      "description": "Aggregate egress (sent to clients) and ingress (received from clients) throughput.",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "Bps"
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(rsync_proxy_sent_bytes_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "legendFormat": "egress (sent)",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(rsync_proxy_received_bytes_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "legendFormat": "ingress (received)",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 200,
+      "type": "row",
+      "title": "Modules & Upstreams",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "panels": []
+    },
+    {
+      "id": 9,
+      "title": "Active Connections by Module (Top 15)",
+      "description": "Active connections grouped by module name.",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "stepAfter",
+            "fillOpacity": 30,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "topk(15, sum by (module) (rsync_proxy_active_connections_by_module{job=\"ic\",instance=\"$instance\"}))",
+          "legendFormat": "{{module}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "title": "Active Connections by Backend (IP:port)",
+      "description": "Active connections grouped by upstream backend address. Note: the 'upstream' label here is the resolved IP:port, distinct from the upstream config name shown in the Queue panels.",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "stepAfter",
+            "fillOpacity": 30,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (upstream) (rsync_proxy_active_connections_by_module{job=\"ic\",instance=\"$instance\"})",
+          "legendFormat": "{{upstream}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 300,
+      "type": "row",
+      "title": "Queue",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "panels": []
+    },
+    {
+      "id": 11,
+      "title": "Queue Status by Upstream",
+      "description": "Per-upstream queue snapshot. queued_max=0 means no limit (NaN in the Util column). Capacity max values come from rsync-proxy config.",
+      "type": "table",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "queued utilization"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "gauge",
+                  "mode": "gradient"
+                }
+              },
+              {
+                "id": "min",
+                "value": 0
+              },
+              {
+                "id": "max",
+                "value": 1
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "orange",
+                      "value": 0.7
+                    },
+                    {
+                      "color": "red",
+                      "value": 0.9
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "queued"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "text",
+                      "value": null
+                    },
+                    {
+                      "color": "orange",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "rejected/h"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "text",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dial errors/h"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "text",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "footer": {
+          "show": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rsync_proxy_queued_connections{job=\"ic\",instance=\"$instance\"}",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rsync_proxy_queue_active_max{job=\"ic\",instance=\"$instance\"}",
+          "format": "table",
+          "instant": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rsync_proxy_queue_queued_max{job=\"ic\",instance=\"$instance\"}",
+          "format": "table",
+          "instant": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rsync_proxy_queued_connections{job=\"ic\",instance=\"$instance\"} / (rsync_proxy_queue_queued_max{job=\"ic\",instance=\"$instance\"} > 0)",
+          "format": "table",
+          "instant": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "increase(rsync_proxy_queue_full_rejected_total{job=\"ic\",instance=\"$instance\"}[1h])",
+          "format": "table",
+          "instant": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "increase(rsync_proxy_upstream_dial_errors_total{job=\"ic\",instance=\"$instance\"}[1h])",
+          "format": "table",
+          "instant": true,
+          "refId": "F"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "upstream",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true,
+              "Time 4": true,
+              "Time 5": true,
+              "Time 6": true,
+              "job 1": true,
+              "job 2": true,
+              "job 3": true,
+              "job 4": true,
+              "job 5": true,
+              "job 6": true,
+              "instance 1": true,
+              "instance 2": true,
+              "instance 3": true,
+              "instance 4": true,
+              "instance 5": true,
+              "instance 6": true,
+              "__name__ 1": true,
+              "__name__ 2": true,
+              "__name__ 3": true,
+              "__name__ 4": true,
+              "__name__ 5": true,
+              "__name__ 6": true
+            },
+            "indexByName": {
+              "upstream": 0,
+              "Value #A": 1,
+              "Value #C": 2,
+              "Value #D": 3,
+              "Value #B": 4,
+              "Value #E": 5,
+              "Value #F": 6
+            },
+            "renameByName": {
+              "upstream": "upstream",
+              "Value #A": "queued",
+              "Value #B": "active_max",
+              "Value #C": "queued_max",
+              "Value #D": "queued utilization",
+              "Value #E": "rejected/h",
+              "Value #F": "dial errors/h"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "title": "Queued Connections by Upstream",
+      "description": "Per-upstream pending queue depth over time.",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "stepAfter",
+            "fillOpacity": 30,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rsync_proxy_queued_connections{job=\"ic\",instance=\"$instance\"}",
+          "legendFormat": "{{upstream}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 500,
+      "type": "row",
+      "title": "Top Modules",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "panels": []
+    },
+    {
+      "id": 15,
+      "title": "Top Modules by Active Connections",
+      "description": "Which modules currently hold the most live connections.",
+      "type": "bargauge",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0,
+          "min": 0
+        }
+      },
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "showUnfilled": true,
+        "valueMode": "color",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "topk(15, sum by (module) (rsync_proxy_active_connections_by_module{job=\"ic\",instance=\"$instance\"}))",
+          "legendFormat": "{{module}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 16,
+      "title": "Live Connections (per-connection snapshot)",
+      "description": "One row per currently-active connection. Bytes are cumulative for the session and reset when the connection ends or rsync-proxy restarts.",
+      "type": "table",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": true
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "duration"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "sent"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "received"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "footer": {
+          "show": false
+        },
+        "sortBy": [
+          {
+            "displayName": "sent",
+            "desc": true
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rsync_proxy_connection_duration_seconds{job=\"ic\",instance=\"$instance\"}",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rsync_proxy_connection_sent_bytes{job=\"ic\",instance=\"$instance\"}",
+          "format": "table",
+          "instant": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rsync_proxy_connection_received_bytes{job=\"ic\",instance=\"$instance\"}",
+          "format": "table",
+          "instant": true,
+          "refId": "C"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "index",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true,
+              "job 1": true,
+              "job 2": true,
+              "job 3": true,
+              "instance 1": true,
+              "instance 2": true,
+              "instance 3": true,
+              "__name__ 1": true,
+              "__name__ 2": true,
+              "__name__ 3": true,
+              "module 2": true,
+              "module 3": true,
+              "upstream 2": true,
+              "upstream 3": true
+            },
+            "indexByName": {
+              "index": 0,
+              "module 1": 1,
+              "upstream 1": 2,
+              "Value #A": 3,
+              "Value #B": 4,
+              "Value #C": 5
+            },
+            "renameByName": {
+              "module 1": "module",
+              "upstream 1": "backend",
+              "Value #A": "duration",
+              "Value #B": "sent",
+              "Value #C": "received"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "id": 700,
+      "type": "row",
+      "title": "Per-Module Lifetime",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
+      "panels": []
+    },
+    {
+      "id": 27,
+      "title": "Module Completed Conn Rate (Top 10)",
+      "description": "Per-module rate of completed connections, summed across upstreams. Source: rsync_proxy_module_completed_connections_total.",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 43
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "cps"
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "sum"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "topk(10, sum by (module) (rate(rsync_proxy_module_completed_connections_total{job=\"ic\",instance=\"$instance\"}[5m])))",
+          "legendFormat": "{{module}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 28,
+      "title": "Module Egress Rate (Top 10)",
+      "description": "Per-module bytes sent rate (to clients). Source: rsync_proxy_module_sent_bytes_total.",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 43
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "Bps"
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "sum"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "topk(10, sum by (module) (rate(rsync_proxy_module_sent_bytes_total{job=\"ic\",instance=\"$instance\"}[5m])))",
+          "legendFormat": "{{module}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 29,
+      "title": "Module Ingress Rate (Top 10)",
+      "description": "Per-module bytes received rate (from clients). Source: rsync_proxy_module_received_bytes_total.",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 43
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "Bps"
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "sum"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "topk(10, sum by (module) (rate(rsync_proxy_module_received_bytes_total{job=\"ic\",instance=\"$instance\"}[5m])))",
+          "legendFormat": "{{module}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 400,
+      "type": "row",
+      "title": "Failures",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 51
+      },
+      "panels": []
+    },
+    {
+      "id": 13,
+      "title": "Failure Rate by Type",
+      "description": "Per-second rate of each failure category, summed across upstreams.",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 52
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "fillOpacity": 10,
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "cps"
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "sum",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(rsync_proxy_queue_full_rejected_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "legendFormat": "queue full (rejected)",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(rsync_proxy_upstream_dial_errors_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "legendFormat": "upstream dial errors",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(rsync_proxy_unknown_module_requests_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "legendFormat": "unknown module",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(rsync_proxy_per_ip_rejected_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "legendFormat": "per-IP cap (rejected)",
+          "refId": "D"
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "title": "Failures by Upstream (last 1h)",
+      "description": "Total failures per upstream in the last hour. Helps locate which backends are misbehaving.",
+      "type": "bargauge",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 52
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0,
+          "min": 0
+        }
+      },
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "showUnfilled": true,
+        "valueMode": "color",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (upstream) (increase(rsync_proxy_queue_full_rejected_total{job=\"ic\",instance=\"$instance\"}[1h])) > 0",
+          "legendFormat": "{{upstream}} (queue full)",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (upstream) (increase(rsync_proxy_upstream_dial_errors_total{job=\"ic\",instance=\"$instance\"}[1h])) > 0",
+          "legendFormat": "{{upstream}} (dial err)",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(increase(rsync_proxy_unknown_module_requests_total{job=\"ic\",instance=\"$instance\"}[1h])) > 0",
+          "legendFormat": "unknown module",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (upstream) (increase(rsync_proxy_per_ip_rejected_total{job=\"ic\",instance=\"$instance\"}[1h])) > 0",
+          "legendFormat": "{{upstream}} (per-IP cap)",
+          "refId": "D"
+        }
+      ]
+    },
+    {
+      "id": 800,
+      "type": "row",
+      "title": "Connection Termination Causes",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 60
+      },
+      "panels": []
+    },
+    {
+      "id": 30,
+      "title": "Termination Rate by Cause",
+      "description": "Per-second rate of watcher-forced terminations: idle timeout, max duration exceeded, throughput floor breached.",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 61
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "fillOpacity": 10,
+            "showPoints": "auto",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "cps"
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "sum",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(rsync_proxy_relay_idle_timeout_terminated_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "legendFormat": "idle timeout",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(rsync_proxy_relay_max_duration_terminated_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "legendFormat": "max duration",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(rsync_proxy_throughput_floor_terminated_total{job=\"ic\",instance=\"$instance\"}[5m]))",
+          "legendFormat": "throughput floor",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "id": 31,
+      "title": "Watcher-Killed Connections (last 1h)",
+      "description": "Total connections forcibly closed by the relay watcher in the last hour.",
+      "type": "stat",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 61
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0
+        }
+      },
+      "options": {
+        "graphMode": "area",
+        "colorMode": "value",
+        "textMode": "auto",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(increase(rsync_proxy_relay_idle_timeout_terminated_total{job=\"ic\",instance=\"$instance\"}[1h])) + sum(increase(rsync_proxy_relay_max_duration_terminated_total{job=\"ic\",instance=\"$instance\"}[1h])) + sum(increase(rsync_proxy_throughput_floor_terminated_total{job=\"ic\",instance=\"$instance\"}[1h]))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 600,
+      "type": "row",
+      "title": "Process & Runtime",
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 69
+      },
+      "panels": [
+        {
+          "id": 17,
+          "title": "Goroutines",
+          "type": "timeseries",
+          "gridPos": {
+            "x": 0,
+            "y": 70,
+            "w": 8,
+            "h": 8
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "color": {
+                "mode": "palette-classic"
+              },
+              "unit": "short"
+            }
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "go_goroutines{job=\"ic\",instance=\"$instance\"}",
+              "legendFormat": "goroutines",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 18,
+          "title": "Memory",
+          "type": "timeseries",
+          "gridPos": {
+            "x": 8,
+            "y": 70,
+            "w": 8,
+            "h": 8
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "color": {
+                "mode": "palette-classic"
+              },
+              "unit": "bytes"
+            }
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "go_memstats_heap_inuse_bytes{job=\"ic\",instance=\"$instance\"}",
+              "legendFormat": "heap inuse",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "go_memstats_heap_alloc_bytes{job=\"ic\",instance=\"$instance\"}",
+              "legendFormat": "heap alloc",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "process_resident_memory_bytes{job=\"ic\",instance=\"$instance\"}",
+              "legendFormat": "RSS",
+              "refId": "C"
+            }
+          ]
+        },
+        {
+          "id": 19,
+          "title": "CPU",
+          "type": "timeseries",
+          "gridPos": {
+            "x": 16,
+            "y": 70,
+            "w": 8,
+            "h": 8
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "color": {
+                "mode": "palette-classic"
+              },
+              "unit": "percentunit",
+              "min": 0
+            }
+          },
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "rate(process_cpu_seconds_total{job=\"ic\",instance=\"$instance\"}[5m])",
+              "legendFormat": "cpu cores used",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 20,
+          "title": "File Descriptors",
+          "type": "timeseries",
+          "gridPos": {
+            "x": 0,
+            "y": 78,
+            "w": 12,
+            "h": 8
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "color": {
+                "mode": "palette-classic"
+              },
+              "unit": "short"
+            }
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "process_open_fds{job=\"ic\",instance=\"$instance\"}",
+              "legendFormat": "open fds",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "process_max_fds{job=\"ic\",instance=\"$instance\"}",
+              "legendFormat": "max fds",
+              "refId": "B"
+            }
+          ]
+        },
+        {
+          "id": 21,
+          "title": "GC Pause",
+          "type": "timeseries",
+          "gridPos": {
+            "x": 12,
+            "y": 78,
+            "w": 12,
+            "h": 8
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "color": {
+                "mode": "palette-classic"
+              },
+              "unit": "s"
+            }
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "rate(go_gc_duration_seconds_sum{job=\"ic\",instance=\"$instance\"}[5m]) / clamp_min(rate(go_gc_duration_seconds_count{job=\"ic\",instance=\"$instance\"}[5m]), 1)",
+              "legendFormat": "avg pause (5m)",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "go_gc_duration_seconds{job=\"ic\",instance=\"$instance\",quantile=\"1.0\"}",
+              "legendFormat": "max pause",
+              "refId": "B"
+            }
+          ]
+        },
+        {
+          "id": 23,
+          "title": "Uptime",
+          "type": "stat",
+          "gridPos": {
+            "x": 0,
+            "y": 86,
+            "w": 8,
+            "h": 4
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 300
+                  },
+                  {
+                    "color": "green",
+                    "value": 3600
+                  }
+                ]
+              },
+              "unit": "s"
+            }
+          },
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "textMode": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "time() - process_start_time_seconds{job=\"ic\",instance=\"$instance\"}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 24,
+          "title": "Last Restart",
+          "type": "stat",
+          "gridPos": {
+            "x": 8,
+            "y": 86,
+            "w": 8,
+            "h": 4
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "blue",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "dateTimeAsLocal"
+            }
+          },
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "textMode": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "process_start_time_seconds{job=\"ic\",instance=\"$instance\"} * 1000",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 25,
+          "title": "Restarts (last 24h)",
+          "description": "Number of process restarts detected in the last 24 hours.",
+          "type": "stat",
+          "gridPos": {
+            "x": 16,
+            "y": 86,
+            "w": 8,
+            "h": 4
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 3
+                  }
+                ]
+              },
+              "unit": "short",
+              "decimals": 0
+            }
+          },
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "textMode": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "changes(process_start_time_seconds{job=\"ic\",instance=\"$instance\"}[24h])",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 26,
+          "title": "Network I/O (socket layer)",
+          "description": "Process-level socket bytes vs rsync-proxy-level bytes. Difference reflects rsync protocol overhead and other connections (e.g. /metrics scrapes).",
+          "type": "timeseries",
+          "gridPos": {
+            "x": 0,
+            "y": 90,
+            "w": 24,
+            "h": 8
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "linear",
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "color": {
+                "mode": "palette-classic"
+              },
+              "unit": "Bps"
+            }
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "rate(process_network_transmit_bytes_total{job=\"ic\",instance=\"$instance\"}[5m])",
+              "legendFormat": "socket tx",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "rate(process_network_receive_bytes_total{job=\"ic\",instance=\"$instance\"}[5m])",
+              "legendFormat": "socket rx",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "rate(rsync_proxy_sent_bytes_total{job=\"ic\",instance=\"$instance\"}[5m])",
+              "legendFormat": "rsync sent",
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "rate(rsync_proxy_received_bytes_total{job=\"ic\",instance=\"$instance\"}[5m])",
+              "legendFormat": "rsync received",
+              "refId": "D"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -15,6 +15,11 @@ type Upstream struct {
 	UseProxyProtocol bool     `toml:"use_proxy_protocol"`
 	MaxActiveConns   int      `toml:"max_active_connections"`
 	MaxQueuedConns   int      `toml:"max_queued_connections"`
+	// PerIPMaxActiveConns overrides the proxy-wide
+	// per_ip_max_active_connections setting for this upstream. A
+	// value of 0 (the default, i.e. field omitted) means the
+	// upstream inherits the proxy-wide value.
+	PerIPMaxActiveConns int `toml:"per_ip_max_active_connections"`
 }
 
 type ProxySettings struct {
@@ -35,6 +40,24 @@ type ProxySettings struct {
 	// rsyncd.conf(5)), which is an I/O timeout. A common choice for
 	// public mirrors is 600.
 	RelayIdleTimeoutSecs int `toml:"relay_idle_timeout"`
+	// RelayMaxDurationSecs is the maximum total wall-clock duration
+	// (in seconds) of the bidirectional relay phase. When exceeded
+	// the proxy closes the connection regardless of activity. 0 (the
+	// default) disables this hard cap. rsync clients will typically
+	// reconnect and resume on the next run.
+	RelayMaxDurationSecs int `toml:"relay_max_duration"`
+	// TCPKeepAliveSecs enables TCP keepalive on accepted client
+	// connections and on dialed upstream connections. The value is
+	// the keepalive period in seconds; 0 (the default) leaves the
+	// OS-default keepalive behavior in place (typically: disabled or
+	// ~2 hours). Enabling this helps detect half-open connections
+	// (peer crashed, NAT reaped) within minutes rather than hours.
+	TCPKeepAliveSecs int `toml:"tcp_keepalive"`
+	// PerIPMaxActiveConns is the proxy-wide default for the per-IP
+	// per-upstream concurrency cap applied during the relay phase.
+	// 0 (the default) disables the limit. Each upstream may
+	// override this via [upstreams.X].per_ip_max_active_connections.
+	PerIPMaxActiveConns int `toml:"per_ip_max_active_connections"`
 }
 
 type Config struct {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -58,6 +58,28 @@ type ProxySettings struct {
 	// 0 (the default) disables the limit. Each upstream may
 	// override this via [upstreams.X].per_ip_max_active_connections.
 	PerIPMaxActiveConns int `toml:"per_ip_max_active_connections"`
+	// DialTimeoutSecs caps how long the proxy waits when dialing an
+	// upstream rsync server. A value of 0 (the default) leaves the
+	// OS-default TCP connect behavior in place (~75s on Linux). When
+	// an upstream is unreachable this surfaces a fast failure to
+	// the client and increments rsync_proxy_upstream_dial_errors_total
+	// without tying up the listener for the full kernel SYN-retry
+	// budget.
+	DialTimeoutSecs int `toml:"dial_timeout"`
+	// MinThroughputBytes, MinThroughputWindowSecs and
+	// MinThroughputGraceSecs together implement a throughput floor
+	// during the relay phase. Within any window of
+	// min_throughput_window seconds the connection must transfer at
+	// least min_throughput_bytes (counting both directions); if it
+	// does not, the proxy closes the connection. The grace period
+	// suppresses the check for the first min_throughput_grace seconds
+	// after the relay starts to avoid killing a slow-start session.
+	// Setting min_throughput_bytes or min_throughput_window to 0 (the
+	// default) disables the floor. min_throughput_grace defaults to
+	// the value of min_throughput_window when 0.
+	MinThroughputBytes      int64 `toml:"min_throughput_bytes"`
+	MinThroughputWindowSecs int   `toml:"min_throughput_window"`
+	MinThroughputGraceSecs  int   `toml:"min_throughput_grace"`
 }
 
 type Config struct {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -26,6 +26,15 @@ type ProxySettings struct {
 	ErrorLog    string `toml:"error_log"`
 	TLSCertFile string `toml:"tls_cert_file"`
 	TLSKeyFile  string `toml:"tls_key_file"`
+	// RelayIdleTimeoutSecs is the idle timeout (in seconds) applied
+	// during the bidirectional relay phase of a connection. If no data
+	// flows in either direction for this duration, the connection is
+	// terminated. 0 (the default) disables the timeout.
+	//
+	// This mirrors the semantics of the rsyncd "timeout" setting (see
+	// rsyncd.conf(5)), which is an I/O timeout. A common choice for
+	// public mirrors is 600.
+	RelayIdleTimeoutSecs int `toml:"relay_idle_timeout"`
 }
 
 type Config struct {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -74,9 +74,9 @@ type ProxySettings struct {
 	// does not, the proxy closes the connection. The grace period
 	// suppresses the check for the first min_throughput_grace seconds
 	// after the relay starts to avoid killing a slow-start session.
-	// Setting min_throughput_bytes or min_throughput_window to 0 (the
-	// default) disables the floor. min_throughput_grace defaults to
-	// the value of min_throughput_window when 0.
+	// Setting min_throughput_bytes to 0 (the default) disables the
+	// floor. min_throughput_window defaults to 60 seconds when 0, and
+	// min_throughput_grace defaults to the effective window when 0.
 	MinThroughputBytes      int64 `toml:"min_throughput_bytes"`
 	MinThroughputWindowSecs int   `toml:"min_throughput_window"`
 	MinThroughputGraceSecs  int   `toml:"min_throughput_grace"`

--- a/pkg/server/metrics.go
+++ b/pkg/server/metrics.go
@@ -97,6 +97,14 @@ func (s *Server) writePrometheusMetrics(w io.Writer, now time.Time) {
 			prometheusEscapeLabelValue(u.Name), c.dialError.Load())
 	}
 
+	_, _ = fmt.Fprintln(w, "# HELP rsync_proxy_per_ip_rejected_total Total connections rejected by the per-IP per-upstream concurrency cap.")
+	_, _ = fmt.Fprintln(w, "# TYPE rsync_proxy_per_ip_rejected_total counter")
+	for _, u := range upstreams {
+		c := s.getUpstreamCounters(u.Name)
+		_, _ = fmt.Fprintf(w, "rsync_proxy_per_ip_rejected_total{upstream=\"%s\"} %d\n",
+			prometheusEscapeLabelValue(u.Name), c.perIPRejected.Load())
+	}
+
 	_, _ = fmt.Fprintln(w, "# HELP rsync_proxy_unknown_module_requests_total Total requests for unknown modules.")
 	_, _ = fmt.Fprintln(w, "# TYPE rsync_proxy_unknown_module_requests_total counter")
 	_, _ = fmt.Fprintf(w, "rsync_proxy_unknown_module_requests_total %d\n", s.unknownModuleCount.Load())

--- a/pkg/server/metrics.go
+++ b/pkg/server/metrics.go
@@ -105,6 +105,30 @@ func (s *Server) writePrometheusMetrics(w io.Writer, now time.Time) {
 			prometheusEscapeLabelValue(u.Name), c.perIPRejected.Load())
 	}
 
+	_, _ = fmt.Fprintln(w, "# HELP rsync_proxy_relay_idle_timeout_terminated_total Total relay connections terminated by the idle timeout watcher per upstream.")
+	_, _ = fmt.Fprintln(w, "# TYPE rsync_proxy_relay_idle_timeout_terminated_total counter")
+	for _, u := range upstreams {
+		c := s.getUpstreamCounters(u.Name)
+		_, _ = fmt.Fprintf(w, "rsync_proxy_relay_idle_timeout_terminated_total{upstream=\"%s\"} %d\n",
+			prometheusEscapeLabelValue(u.Name), c.idleTerminated.Load())
+	}
+
+	_, _ = fmt.Fprintln(w, "# HELP rsync_proxy_relay_max_duration_terminated_total Total relay connections terminated for exceeding the max-duration cap per upstream.")
+	_, _ = fmt.Fprintln(w, "# TYPE rsync_proxy_relay_max_duration_terminated_total counter")
+	for _, u := range upstreams {
+		c := s.getUpstreamCounters(u.Name)
+		_, _ = fmt.Fprintf(w, "rsync_proxy_relay_max_duration_terminated_total{upstream=\"%s\"} %d\n",
+			prometheusEscapeLabelValue(u.Name), c.maxDurationTerminated.Load())
+	}
+
+	_, _ = fmt.Fprintln(w, "# HELP rsync_proxy_throughput_floor_terminated_total Total relay connections terminated for falling below the configured throughput floor per upstream.")
+	_, _ = fmt.Fprintln(w, "# TYPE rsync_proxy_throughput_floor_terminated_total counter")
+	for _, u := range upstreams {
+		c := s.getUpstreamCounters(u.Name)
+		_, _ = fmt.Fprintf(w, "rsync_proxy_throughput_floor_terminated_total{upstream=\"%s\"} %d\n",
+			prometheusEscapeLabelValue(u.Name), c.throughputFloorTerminated.Load())
+	}
+
 	_, _ = fmt.Fprintln(w, "# HELP rsync_proxy_unknown_module_requests_total Total requests for unknown modules.")
 	_, _ = fmt.Fprintln(w, "# TYPE rsync_proxy_unknown_module_requests_total counter")
 	_, _ = fmt.Fprintf(w, "rsync_proxy_unknown_module_requests_total %d\n", s.unknownModuleCount.Load())

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -129,11 +129,11 @@ type upstreamConfig struct {
 
 // upstreamCounters holds per-upstream failure counters.
 type upstreamCounters struct {
-	queueFull               atomic.Uint64
-	dialError               atomic.Uint64
-	perIPRejected           atomic.Uint64
-	idleTerminated          atomic.Uint64
-	maxDurationTerminated   atomic.Uint64
+	queueFull                 atomic.Uint64
+	dialError                 atomic.Uint64
+	perIPRejected             atomic.Uint64
+	idleTerminated            atomic.Uint64
+	maxDurationTerminated     atomic.Uint64
 	throughputFloorTerminated atomic.Uint64
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -119,12 +119,26 @@ type upstreamConfig struct {
 	DiscoverModules bool
 	MaxActiveConns  int
 	MaxQueuedConns  int
+	// PerIPMaxActiveConns is the resolved (effective) limit on the
+	// number of concurrent active relay connections from a single
+	// client IP to this upstream. 0 means no per-IP cap. Computed at
+	// load time as: per-upstream override (Upstream.PerIPMaxActiveConns)
+	// or, if zero, the proxy-wide default (Proxy.PerIPMaxActiveConns).
+	PerIPMaxActiveConns int
 }
 
 // upstreamCounters holds per-upstream failure counters.
 type upstreamCounters struct {
-	queueFull atomic.Uint64
-	dialError atomic.Uint64
+	queueFull     atomic.Uint64
+	dialError     atomic.Uint64
+	perIPRejected atomic.Uint64
+}
+
+// perIPCountKey identifies a (upstream, client IP) pair for tracking
+// per-IP per-upstream concurrent active relay connections.
+type perIPCountKey struct {
+	upstream string
+	ip       string
 }
 
 // moduleUpstreamKey identifies a (module, upstream) pair for per-module
@@ -160,6 +174,18 @@ type Server struct {
 	// rsyncd.conf(5).
 	RelayIdleTimeout time.Duration
 
+	// RelayMaxDuration is a hard cap on the total wall-clock
+	// duration of the bidirectional relay phase of a connection.
+	// When exceeded the proxy closes both directions regardless of
+	// activity. 0 (the default) disables the cap.
+	RelayMaxDuration time.Duration
+
+	// TCPKeepAlive is the keepalive period applied to accepted
+	// client connections and to dialed upstream connections. 0 (the
+	// default) leaves the OS-default keepalive behavior in place
+	// (typically: disabled, or ~2 hours).
+	TCPKeepAlive time.Duration
+
 	Motd string
 	// --- End of options section
 
@@ -192,6 +218,11 @@ type Server struct {
 	// successfully. Lazy-initialized via getModuleCounters.
 	// map key is moduleUpstreamKey. Value is *moduleCounters.
 	moduleCounters sync.Map
+
+	// Per-(upstream, client IP) active-connection counters.
+	// Lazy-initialized via getPerIPCounter.
+	// map key is perIPCountKey. Value is *atomic.Int64.
+	perIPCounts sync.Map
 
 	TCPListener  net.Listener
 	TLSListener  net.Listener
@@ -261,6 +292,16 @@ func (s *Server) loadConfig(c *Config, openLog bool) error {
 		tlsCertificate = &cert
 	}
 
+	if c.Proxy.RelayMaxDurationSecs < 0 {
+		return fmt.Errorf("relay_max_duration must be non-negative, got %d", c.Proxy.RelayMaxDurationSecs)
+	}
+	if c.Proxy.TCPKeepAliveSecs < 0 {
+		return fmt.Errorf("tcp_keepalive must be non-negative, got %d", c.Proxy.TCPKeepAliveSecs)
+	}
+	if c.Proxy.PerIPMaxActiveConns < 0 {
+		return fmt.Errorf("per_ip_max_active_connections must be non-negative, got %d", c.Proxy.PerIPMaxActiveConns)
+	}
+
 	upstreams := make([]upstreamConfig, 0, len(c.Upstreams))
 	upstreamNames := make([]string, 0, len(c.Upstreams))
 	for upstreamName := range c.Upstreams {
@@ -272,17 +313,27 @@ func (s *Server) loadConfig(c *Config, openLog bool) error {
 		if len(v.Modules) == 0 && !v.DiscoverModules {
 			return fmt.Errorf("upstream=%s must set modules or discover_modules", upstreamName)
 		}
+		if v.PerIPMaxActiveConns < 0 {
+			return fmt.Errorf("upstream=%s: per_ip_max_active_connections must be non-negative, got %d", upstreamName, v.PerIPMaxActiveConns)
+		}
 		addr := v.Address
 		if err := validateTCPOrUnixAddr(addr); err != nil {
 			return fmt.Errorf("resolve address: %w, upstream=%s, address=%s", err, upstreamName, addr)
 		}
+		// Resolve effective per-IP cap: per-upstream override wins;
+		// fall back to proxy-wide default; 0 means no cap.
+		effectivePerIP := v.PerIPMaxActiveConns
+		if effectivePerIP == 0 {
+			effectivePerIP = c.Proxy.PerIPMaxActiveConns
+		}
 		upstreams = append(upstreams, upstreamConfig{
-			Name:            upstreamName,
-			Target:          Target{Upstream: upstreamName, Addr: addr, UseProxyProtocol: v.UseProxyProtocol},
-			Modules:         slices.Clone(v.Modules),
-			DiscoverModules: v.DiscoverModules,
-			MaxActiveConns:  v.MaxActiveConns,
-			MaxQueuedConns:  v.MaxQueuedConns,
+			Name:                upstreamName,
+			Target:              Target{Upstream: upstreamName, Addr: addr, UseProxyProtocol: v.UseProxyProtocol},
+			Modules:             slices.Clone(v.Modules),
+			DiscoverModules:     v.DiscoverModules,
+			MaxActiveConns:      v.MaxActiveConns,
+			MaxQueuedConns:      v.MaxQueuedConns,
+			PerIPMaxActiveConns: effectivePerIP,
 		})
 	}
 
@@ -321,6 +372,12 @@ func (s *Server) loadConfig(c *Config, openLog bool) error {
 		return fmt.Errorf("relay_idle_timeout must be non-negative, got %d", c.Proxy.RelayIdleTimeoutSecs)
 	}
 	s.RelayIdleTimeout = time.Duration(c.Proxy.RelayIdleTimeoutSecs) * time.Second
+	s.RelayMaxDuration = time.Duration(c.Proxy.RelayMaxDurationSecs) * time.Second
+	s.TCPKeepAlive = time.Duration(c.Proxy.TCPKeepAliveSecs) * time.Second
+	// Reflect the new keepalive setting on the dialer used to dial
+	// upstreams. The dialer is consulted under reloadLock via
+	// getDialer() to avoid racing with reloads.
+	s.dialer.KeepAlive = s.TCPKeepAlive
 	s.modules = modules
 	s.upstreams = resolvedUpstreams
 	s.upstreamQueues = s.updateUpstreamQueuesLocked(resolvedUpstreams)
@@ -336,12 +393,13 @@ func resolveUpstreams(upstreams []upstreamConfig, discovered map[string][]string
 			modules = slices.Clone(discovered[upstream.Name])
 		}
 		resolved = append(resolved, upstreamConfig{
-			Name:            upstream.Name,
-			Target:          upstream.Target,
-			Modules:         modules,
-			DiscoverModules: upstream.DiscoverModules,
-			MaxActiveConns:  upstream.MaxActiveConns,
-			MaxQueuedConns:  upstream.MaxQueuedConns,
+			Name:                upstream.Name,
+			Target:              upstream.Target,
+			Modules:             modules,
+			DiscoverModules:     upstream.DiscoverModules,
+			MaxActiveConns:      upstream.MaxActiveConns,
+			MaxQueuedConns:      upstream.MaxQueuedConns,
+			PerIPMaxActiveConns: upstream.PerIPMaxActiveConns,
 		})
 	}
 	return resolved
@@ -403,6 +461,73 @@ func (s *Server) getModuleCounters(module, upstream string) *moduleCounters {
 	}
 	v, _ := s.moduleCounters.LoadOrStore(key, &moduleCounters{})
 	return v.(*moduleCounters)
+}
+
+// getPerIPCounter returns the (upstream, ip) active-connection counter,
+// creating it lazily. Safe for concurrent use.
+func (s *Server) getPerIPCounter(upstream, ip string) *atomic.Int64 {
+	key := perIPCountKey{upstream: upstream, ip: ip}
+	if v, ok := s.perIPCounts.Load(key); ok {
+		return v.(*atomic.Int64)
+	}
+	v, _ := s.perIPCounts.LoadOrStore(key, &atomic.Int64{})
+	return v.(*atomic.Int64)
+}
+
+// getDialer returns a copy of the current upstream dialer, taking the
+// reload lock to avoid racing with config reloads that mutate the
+// dialer (e.g. KeepAlive). The returned value is safe to pass by value
+// to dialContextTCPOrUnix.
+func (s *Server) getDialer() net.Dialer {
+	s.reloadLock.RLock()
+	defer s.reloadLock.RUnlock()
+	return s.dialer
+}
+
+// getRelayTimings returns a snapshot of the relay-phase timing
+// settings under the reload lock. These fields are mutated by config
+// reloads, so callers must not read them directly.
+func (s *Server) getRelayTimings() (idle, maxDuration, tcpKeepAlive time.Duration) {
+	s.reloadLock.RLock()
+	defer s.reloadLock.RUnlock()
+	return s.RelayIdleTimeout, s.RelayMaxDuration, s.TCPKeepAlive
+}
+
+// getTCPKeepAlive returns the configured TCP keepalive period under
+// the reload lock.
+func (s *Server) getTCPKeepAlive() time.Duration {
+	s.reloadLock.RLock()
+	defer s.reloadLock.RUnlock()
+	return s.TCPKeepAlive
+}
+
+// getPerIPLimitForUpstream returns the configured per-IP active
+// connection cap for the named upstream, or 0 if none is set or the
+// upstream is unknown. Safe for concurrent use.
+func (s *Server) getPerIPLimitForUpstream(name string) int {
+	s.reloadLock.RLock()
+	defer s.reloadLock.RUnlock()
+	for i := range s.upstreams {
+		if s.upstreams[i].Name == name {
+			return s.upstreams[i].PerIPMaxActiveConns
+		}
+	}
+	return 0
+}
+
+// applyTCPKeepAlive enables TCP keepalive on the given connection if
+// it is a *net.TCPConn and a positive period is provided. Other
+// connection types (e.g. unix sockets) are silently ignored.
+func applyTCPKeepAlive(conn net.Conn, period time.Duration) {
+	if period <= 0 {
+		return
+	}
+	tc, ok := conn.(*net.TCPConn)
+	if !ok {
+		return
+	}
+	_ = tc.SetKeepAlive(true)
+	_ = tc.SetKeepAlivePeriod(period)
 }
 
 func buildModuleTargets(upstreams []upstreamConfig) map[string][]Target {
@@ -672,6 +797,23 @@ func (s *Server) relay(ctx context.Context, index uint32, downConn net.Conn) err
 		return fmt.Errorf("no queue configured for upstream %s", target.Upstream)
 	}
 
+	// Per-IP per-upstream concurrency cap. A positive cap means the
+	// same client IP may not have more than N simultaneous active
+	// relay connections to this upstream. Counted before queue
+	// admission so the cap also bounds queueing, preventing a single
+	// IP from monopolizing both the active slots and the queue.
+	if perIPLimit := s.getPerIPLimitForUpstream(target.Upstream); perIPLimit > 0 {
+		counter := s.getPerIPCounter(target.Upstream, ip)
+		if n := counter.Add(1); int(n) > perIPLimit {
+			counter.Add(-1)
+			s.getUpstreamCounters(target.Upstream).perIPRejected.Add(1)
+			s.accessLog.F("client %s rejected for upstream %s module %s: per-IP cap of %d reached", ip, target.Upstream, moduleName, perIPLimit)
+			_, _ = writeWithTimeout(downConn, fmt.Appendf(nil, "@ERROR: per-IP connection limit of %d for upstream %s reached, retry later\n", perIPLimit, target.Upstream), writeTimeout)
+			return nil
+		}
+		defer counter.Add(-1)
+	}
+
 	handle := upstreamQueue.Acquire()
 	defer handle.Release()
 	status := <-handle.C
@@ -710,12 +852,19 @@ func (s *Server) relay(ctx context.Context, index uint32, downConn net.Conn) err
 		}
 	}
 
-	upConn, err := dialContextTCPOrUnix(ctx, s.dialer, upstreamAddr)
+	upConn, err := dialContextTCPOrUnix(ctx, s.getDialer(), upstreamAddr)
 	if err != nil {
 		s.getUpstreamCounters(target.Upstream).dialError.Add(1)
 		return fmt.Errorf("dial to upstream: %s: %w", upstreamAddr, err)
 	}
 	defer upConn.Close()
+	// Enable TCP keepalive on the upstream-side connection so that a
+	// dead/half-open peer is detected within the configured period
+	// rather than relying on the OS default (commonly ~2 hours, or
+	// disabled). dialer.KeepAlive only takes effect for the initial
+	// SYN window; explicitly setting it on the resulting *TCPConn
+	// is portable and idempotent.
+	applyTCPKeepAlive(upConn, s.getTCPKeepAlive())
 	upAddr := netAddrToString(upConn.RemoteAddr())
 	if useProxyProtocol {
 		err := writeProxyProtocolHeader(upConn, downConn.RemoteAddr(), upConn.RemoteAddr(), s.WriteTimeout)
@@ -764,27 +913,46 @@ func (s *Server) relay(ctx context.Context, index uint32, downConn net.Conn) err
 	downReader := &countingReader{reader: downConn, counter: &info.ReceivedBytes}
 	upReader := &countingReader{reader: upConn, counter: &info.SentBytes}
 
-	// If an idle timeout is configured, share a single lastActivity
-	// timestamp between the two directions and start a watcher
-	// goroutine that tears the connections down when no data has
-	// flowed in either direction for the configured duration. This
-	// mirrors rsyncd's "timeout" semantics (rsyncd.conf(5)).
-	idleTimeout := s.RelayIdleTimeout
+	// Optional watchers on the bidirectional relay phase:
+	//   * RelayIdleTimeout terminates a connection that has had no
+	//     data flow in either direction for the configured duration
+	//     (rsyncd "timeout" semantics, rsyncd.conf(5)).
+	//   * RelayMaxDuration is a hard wall-clock cap on the entire
+	//     relay phase; any connection still alive past this point is
+	//     terminated regardless of activity.
+	// A single goroutine handles both checks. The shared
+	// idleTimedOut flag is used by the io.Copy goroutines to
+	// suppress the expected "use of closed network connection" error
+	// log when the watcher initiated the close.
+	idleTimeout, maxDuration, _ := s.getRelayTimings()
+	relayStartedAt := time.Now()
 	var idleTimedOut atomic.Bool
 	sentClosed := make(chan struct{})
 	receivedClosed := make(chan struct{})
 
-	if idleTimeout > 0 {
-		lastActivity := &atomic.Int64{}
-		lastActivity.Store(time.Now().UnixNano())
-		downReader.lastActivity = lastActivity
-		upReader.lastActivity = lastActivity
+	if idleTimeout > 0 || maxDuration > 0 {
+		var lastActivity *atomic.Int64
+		if idleTimeout > 0 {
+			lastActivity = &atomic.Int64{}
+			lastActivity.Store(relayStartedAt.UnixNano())
+			downReader.lastActivity = lastActivity
+			upReader.lastActivity = lastActivity
+		}
 
-		// Wake at most a few times per timeout window so a stalled
-		// connection is detected within roughly 1.25x the configured
-		// timeout in the worst case, while keeping wakeup overhead
-		// negligible.
-		interval := idleTimeout / 4
+		// Wake at most a few times per the smaller of the two
+		// configured windows so timeouts are detected within roughly
+		// 1.25x the configured value in the worst case, while keeping
+		// wakeup overhead negligible.
+		interval := time.Duration(0)
+		if idleTimeout > 0 {
+			interval = idleTimeout / 4
+		}
+		if maxDuration > 0 {
+			d := maxDuration / 4
+			if interval == 0 || d < interval {
+				interval = d
+			}
+		}
 		if interval < time.Second {
 			interval = time.Second
 		}
@@ -799,10 +967,19 @@ func (s *Server) relay(ctx context.Context, index uint32, downConn net.Conn) err
 				case <-receivedClosed:
 					return
 				case now := <-ticker.C:
-					last := time.Unix(0, lastActivity.Load())
-					if now.Sub(last) >= idleTimeout {
+					if idleTimeout > 0 {
+						last := time.Unix(0, lastActivity.Load())
+						if now.Sub(last) >= idleTimeout {
+							idleTimedOut.Store(true)
+							s.accessLog.F("client %s idle for module %s exceeds %s, closing", ip, moduleName, idleTimeout)
+							_ = upConn.Close()
+							_ = downConn.Close()
+							return
+						}
+					}
+					if maxDuration > 0 && now.Sub(relayStartedAt) >= maxDuration {
 						idleTimedOut.Store(true)
-						s.accessLog.F("client %s idle for module %s exceeds %s, closing", ip, moduleName, idleTimeout)
+						s.accessLog.F("client %s exceeded max relay duration %s for module %s, closing", ip, maxDuration, moduleName)
 						_ = upConn.Close()
 						_ = downConn.Close()
 						return
@@ -1049,6 +1226,12 @@ func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
 	defer s.activeConnCount.Add(-1)
 	s.acceptedConnCount.Add(1)
 	connIndex := s.connIndex.Add(1)
+
+	// Apply TCP keepalive on the accepted client connection so that
+	// half-open connections (peer crashed, NAT entry reaped) are
+	// detected within the configured period rather than waiting for
+	// the OS default. No-op on unix-domain or non-TCP listeners.
+	applyTCPKeepAlive(conn, s.getTCPKeepAlive())
 
 	defer func() {
 		err := recover()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -153,6 +153,13 @@ type Server struct {
 	ReadTimeout  time.Duration
 	WriteTimeout time.Duration
 
+	// RelayIdleTimeout is the idle (no I/O activity in either
+	// direction) timeout applied during the bidirectional relay phase
+	// of a connection. A value of 0 (the default) disables the
+	// timeout, matching rsyncd's "timeout = 0" behavior. See
+	// rsyncd.conf(5).
+	RelayIdleTimeout time.Duration
+
 	Motd string
 	// --- End of options section
 
@@ -194,12 +201,20 @@ type Server struct {
 type countingReader struct {
 	reader  io.Reader
 	counter *atomic.Int64
+	// lastActivity is the UnixNano timestamp of the most recent
+	// successful read (n > 0). It is updated atomically so that an
+	// idle watcher goroutine can observe activity without locking.
+	// May be nil when activity tracking is not needed.
+	lastActivity *atomic.Int64
 }
 
 func (cr *countingReader) Read(p []byte) (n int, err error) {
 	n, err = cr.reader.Read(p)
 	if n > 0 {
 		cr.counter.Add(int64(n))
+		if cr.lastActivity != nil {
+			cr.lastActivity.Store(time.Now().UnixNano())
+		}
 	}
 	return n, err
 }
@@ -302,6 +317,10 @@ func (s *Server) loadConfig(c *Config, openLog bool) error {
 		}
 	}
 	s.Motd = c.Proxy.Motd
+	if c.Proxy.RelayIdleTimeoutSecs < 0 {
+		return fmt.Errorf("relay_idle_timeout must be non-negative, got %d", c.Proxy.RelayIdleTimeoutSecs)
+	}
+	s.RelayIdleTimeout = time.Duration(c.Proxy.RelayIdleTimeoutSecs) * time.Second
 	s.modules = modules
 	s.upstreams = resolvedUpstreams
 	s.upstreamQueues = s.updateUpstreamQueuesLocked(resolvedUpstreams)
@@ -745,19 +764,64 @@ func (s *Server) relay(ctx context.Context, index uint32, downConn net.Conn) err
 	downReader := &countingReader{reader: downConn, counter: &info.ReceivedBytes}
 	upReader := &countingReader{reader: upConn, counter: &info.SentBytes}
 
+	// If an idle timeout is configured, share a single lastActivity
+	// timestamp between the two directions and start a watcher
+	// goroutine that tears the connections down when no data has
+	// flowed in either direction for the configured duration. This
+	// mirrors rsyncd's "timeout" semantics (rsyncd.conf(5)).
+	idleTimeout := s.RelayIdleTimeout
+	var idleTimedOut atomic.Bool
 	sentClosed := make(chan struct{})
 	receivedClosed := make(chan struct{})
 
+	if idleTimeout > 0 {
+		lastActivity := &atomic.Int64{}
+		lastActivity.Store(time.Now().UnixNano())
+		downReader.lastActivity = lastActivity
+		upReader.lastActivity = lastActivity
+
+		// Wake at most a few times per timeout window so a stalled
+		// connection is detected within roughly 1.25x the configured
+		// timeout in the worst case, while keeping wakeup overhead
+		// negligible.
+		interval := idleTimeout / 4
+		if interval < time.Second {
+			interval = time.Second
+		}
+
+		go func() {
+			ticker := time.NewTicker(interval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-sentClosed:
+					return
+				case <-receivedClosed:
+					return
+				case now := <-ticker.C:
+					last := time.Unix(0, lastActivity.Load())
+					if now.Sub(last) >= idleTimeout {
+						idleTimedOut.Store(true)
+						s.accessLog.F("client %s idle for module %s exceeds %s, closing", ip, moduleName, idleTimeout)
+						_ = upConn.Close()
+						_ = downConn.Close()
+						return
+					}
+				}
+			}
+		}()
+	}
+
 	go func() {
 		_, err := io.Copy(upConn, downReader)
-		if err != nil {
+		if err != nil && !idleTimedOut.Load() {
 			s.errorLog.F("copy from downstream to upstream: %v", err)
 		}
 		close(sentClosed)
 	}()
 	go func() {
 		_, err := io.Copy(downConn, upReader)
-		if err != nil {
+		if err != nil && !idleTimedOut.Load() {
 			s.errorLog.F("copy from upstream to downstream: %v", err)
 		}
 		close(receivedClosed)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -129,9 +129,12 @@ type upstreamConfig struct {
 
 // upstreamCounters holds per-upstream failure counters.
 type upstreamCounters struct {
-	queueFull     atomic.Uint64
-	dialError     atomic.Uint64
-	perIPRejected atomic.Uint64
+	queueFull               atomic.Uint64
+	dialError               atomic.Uint64
+	perIPRejected           atomic.Uint64
+	idleTerminated          atomic.Uint64
+	maxDurationTerminated   atomic.Uint64
+	throughputFloorTerminated atomic.Uint64
 }
 
 // perIPCountKey identifies a (upstream, client IP) pair for tracking
@@ -185,6 +188,19 @@ type Server struct {
 	// default) leaves the OS-default keepalive behavior in place
 	// (typically: disabled, or ~2 hours).
 	TCPKeepAlive time.Duration
+
+	// MinThroughputBytes, MinThroughputWindow and
+	// MinThroughputGrace together implement a throughput floor
+	// during the relay phase. Within any window of
+	// MinThroughputWindow the connection must transfer at least
+	// MinThroughputBytes (counting both directions); otherwise the
+	// proxy closes the connection. The grace period suppresses the
+	// check for the first MinThroughputGrace after the relay
+	// starts. Setting MinThroughputBytes or MinThroughputWindow to
+	// zero disables the floor.
+	MinThroughputBytes  int64
+	MinThroughputWindow time.Duration
+	MinThroughputGrace  time.Duration
 
 	Motd string
 	// --- End of options section
@@ -301,6 +317,18 @@ func (s *Server) loadConfig(c *Config, openLog bool) error {
 	if c.Proxy.PerIPMaxActiveConns < 0 {
 		return fmt.Errorf("per_ip_max_active_connections must be non-negative, got %d", c.Proxy.PerIPMaxActiveConns)
 	}
+	if c.Proxy.DialTimeoutSecs < 0 {
+		return fmt.Errorf("dial_timeout must be non-negative, got %d", c.Proxy.DialTimeoutSecs)
+	}
+	if c.Proxy.MinThroughputBytes < 0 {
+		return fmt.Errorf("min_throughput_bytes must be non-negative, got %d", c.Proxy.MinThroughputBytes)
+	}
+	if c.Proxy.MinThroughputWindowSecs < 0 {
+		return fmt.Errorf("min_throughput_window must be non-negative, got %d", c.Proxy.MinThroughputWindowSecs)
+	}
+	if c.Proxy.MinThroughputGraceSecs < 0 {
+		return fmt.Errorf("min_throughput_grace must be non-negative, got %d", c.Proxy.MinThroughputGraceSecs)
+	}
 
 	upstreams := make([]upstreamConfig, 0, len(c.Upstreams))
 	upstreamNames := make([]string, 0, len(c.Upstreams))
@@ -374,10 +402,21 @@ func (s *Server) loadConfig(c *Config, openLog bool) error {
 	s.RelayIdleTimeout = time.Duration(c.Proxy.RelayIdleTimeoutSecs) * time.Second
 	s.RelayMaxDuration = time.Duration(c.Proxy.RelayMaxDurationSecs) * time.Second
 	s.TCPKeepAlive = time.Duration(c.Proxy.TCPKeepAliveSecs) * time.Second
-	// Reflect the new keepalive setting on the dialer used to dial
-	// upstreams. The dialer is consulted under reloadLock via
-	// getDialer() to avoid racing with reloads.
+	s.MinThroughputBytes = c.Proxy.MinThroughputBytes
+	s.MinThroughputWindow = time.Duration(c.Proxy.MinThroughputWindowSecs) * time.Second
+	graceSecs := c.Proxy.MinThroughputGraceSecs
+	if graceSecs == 0 {
+		// Default the grace period to the window itself: a fresh
+		// connection gets one full window to ramp up before the
+		// floor is enforced.
+		graceSecs = c.Proxy.MinThroughputWindowSecs
+	}
+	s.MinThroughputGrace = time.Duration(graceSecs) * time.Second
+	// Reflect the new keepalive and dial-timeout settings on the
+	// dialer used to dial upstreams. The dialer is consulted under
+	// reloadLock via getDialer() to avoid racing with reloads.
 	s.dialer.KeepAlive = s.TCPKeepAlive
+	s.dialer.Timeout = time.Duration(c.Proxy.DialTimeoutSecs) * time.Second
 	s.modules = modules
 	s.upstreams = resolvedUpstreams
 	s.upstreamQueues = s.updateUpstreamQueuesLocked(resolvedUpstreams)
@@ -484,13 +523,33 @@ func (s *Server) getDialer() net.Dialer {
 	return s.dialer
 }
 
+// relayTimings is a snapshot of all relay-phase timing settings,
+// captured atomically under the reload lock. Callers should consume
+// this snapshot for the lifetime of a single relay connection so the
+// behavior remains consistent across reloads.
+type relayTimings struct {
+	idle         time.Duration
+	maxDuration  time.Duration
+	tcpKeepAlive time.Duration
+	minBytes     int64
+	minWindow    time.Duration
+	minGrace     time.Duration
+}
+
 // getRelayTimings returns a snapshot of the relay-phase timing
 // settings under the reload lock. These fields are mutated by config
 // reloads, so callers must not read them directly.
-func (s *Server) getRelayTimings() (idle, maxDuration, tcpKeepAlive time.Duration) {
+func (s *Server) getRelayTimings() relayTimings {
 	s.reloadLock.RLock()
 	defer s.reloadLock.RUnlock()
-	return s.RelayIdleTimeout, s.RelayMaxDuration, s.TCPKeepAlive
+	return relayTimings{
+		idle:         s.RelayIdleTimeout,
+		maxDuration:  s.RelayMaxDuration,
+		tcpKeepAlive: s.TCPKeepAlive,
+		minBytes:     s.MinThroughputBytes,
+		minWindow:    s.MinThroughputWindow,
+		minGrace:     s.MinThroughputGrace,
+	}
 }
 
 // getTCPKeepAlive returns the configured TCP keepalive period under
@@ -920,17 +979,31 @@ func (s *Server) relay(ctx context.Context, index uint32, downConn net.Conn) err
 	//   * RelayMaxDuration is a hard wall-clock cap on the entire
 	//     relay phase; any connection still alive past this point is
 	//     terminated regardless of activity.
-	// A single goroutine handles both checks. The shared
-	// idleTimedOut flag is used by the io.Copy goroutines to
+	//   * MinThroughputBytes/MinThroughputWindow enforce a minimum
+	//     average throughput on the relay; a connection that has
+	//     transferred fewer than minBytes over the last window is
+	//     considered to be slow-leeching and terminated. The grace
+	//     period suppresses the check during initial ramp-up so
+	//     short rsync exchanges (file lists, etc.) are not killed.
+	// A single goroutine handles all checks. The shared
+	// watcherClosed flag is used by the io.Copy goroutines to
 	// suppress the expected "use of closed network connection" error
-	// log when the watcher initiated the close.
-	idleTimeout, maxDuration, _ := s.getRelayTimings()
+	// log when the watcher initiated the close. The reason for the
+	// closure is recorded directly by the watcher into per-upstream
+	// counters and access log.
+	timings := s.getRelayTimings()
+	idleTimeout := timings.idle
+	maxDuration := timings.maxDuration
+	minBytes := timings.minBytes
+	minWindow := timings.minWindow
+	minGrace := timings.minGrace
+	throughputEnabled := minBytes > 0 && minWindow > 0
 	relayStartedAt := time.Now()
 	var idleTimedOut atomic.Bool
 	sentClosed := make(chan struct{})
 	receivedClosed := make(chan struct{})
 
-	if idleTimeout > 0 || maxDuration > 0 {
+	if idleTimeout > 0 || maxDuration > 0 || throughputEnabled {
 		var lastActivity *atomic.Int64
 		if idleTimeout > 0 {
 			lastActivity = &atomic.Int64{}
@@ -939,27 +1012,43 @@ func (s *Server) relay(ctx context.Context, index uint32, downConn net.Conn) err
 			upReader.lastActivity = lastActivity
 		}
 
-		// Wake at most a few times per the smaller of the two
+		// Wake at most a few times per the smallest of the
 		// configured windows so timeouts are detected within roughly
 		// 1.25x the configured value in the worst case, while keeping
 		// wakeup overhead negligible.
 		interval := time.Duration(0)
-		if idleTimeout > 0 {
-			interval = idleTimeout / 4
-		}
-		if maxDuration > 0 {
-			d := maxDuration / 4
+		bumpInterval := func(d time.Duration) {
+			if d <= 0 {
+				return
+			}
 			if interval == 0 || d < interval {
 				interval = d
 			}
+		}
+		if idleTimeout > 0 {
+			bumpInterval(idleTimeout / 4)
+		}
+		if maxDuration > 0 {
+			bumpInterval(maxDuration / 4)
+		}
+		if throughputEnabled {
+			bumpInterval(minWindow / 4)
 		}
 		if interval < time.Second {
 			interval = time.Second
 		}
 
+		upstreamName := target.Upstream
 		go func() {
 			ticker := time.NewTicker(interval)
 			defer ticker.Stop()
+			// Sliding-window throughput state. lastSampleTime moves
+			// forward each time we reach a full window, with
+			// lastSampleBytes capturing the cumulative byte count at
+			// that moment. delta over the next window must meet
+			// minBytes or the connection is terminated.
+			lastSampleTime := relayStartedAt
+			lastSampleBytes := int64(0)
 			for {
 				select {
 				case <-sentClosed:
@@ -971,6 +1060,7 @@ func (s *Server) relay(ctx context.Context, index uint32, downConn net.Conn) err
 						last := time.Unix(0, lastActivity.Load())
 						if now.Sub(last) >= idleTimeout {
 							idleTimedOut.Store(true)
+							s.getUpstreamCounters(upstreamName).idleTerminated.Add(1)
 							s.accessLog.F("client %s idle for module %s exceeds %s, closing", ip, moduleName, idleTimeout)
 							_ = upConn.Close()
 							_ = downConn.Close()
@@ -979,10 +1069,26 @@ func (s *Server) relay(ctx context.Context, index uint32, downConn net.Conn) err
 					}
 					if maxDuration > 0 && now.Sub(relayStartedAt) >= maxDuration {
 						idleTimedOut.Store(true)
+						s.getUpstreamCounters(upstreamName).maxDurationTerminated.Add(1)
 						s.accessLog.F("client %s exceeded max relay duration %s for module %s, closing", ip, maxDuration, moduleName)
 						_ = upConn.Close()
 						_ = downConn.Close()
 						return
+					}
+					if throughputEnabled && now.Sub(relayStartedAt) >= minGrace && now.Sub(lastSampleTime) >= minWindow {
+						curBytes := info.SentBytes.Load() + info.ReceivedBytes.Load()
+						delta := curBytes - lastSampleBytes
+						if delta < minBytes {
+							idleTimedOut.Store(true)
+							s.getUpstreamCounters(upstreamName).throughputFloorTerminated.Add(1)
+							s.accessLog.F("client %s for module %s below throughput floor (%d bytes < %d bytes in %s), closing",
+								ip, moduleName, delta, minBytes, minWindow)
+							_ = upConn.Close()
+							_ = downConn.Close()
+							return
+						}
+						lastSampleTime = now
+						lastSampleBytes = curBytes
 					}
 				}
 			}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -863,7 +863,7 @@ func (s *Server) relay(ctx context.Context, index uint32, downConn net.Conn) err
 	// IP from monopolizing both the active slots and the queue.
 	if perIPLimit := s.getPerIPLimitForUpstream(target.Upstream); perIPLimit > 0 {
 		counter := s.getPerIPCounter(target.Upstream, ip)
-		if n := counter.Add(1); int(n) > perIPLimit {
+		if n := counter.Add(1); n > int64(perIPLimit) {
 			counter.Add(-1)
 			s.getUpstreamCounters(target.Upstream).perIPRejected.Add(1)
 			s.accessLog.F("client %s rejected for upstream %s module %s: per-IP cap of %d reached", ip, target.Upstream, moduleName, perIPLimit)
@@ -1012,10 +1012,14 @@ func (s *Server) relay(ctx context.Context, index uint32, downConn net.Conn) err
 			upReader.lastActivity = lastActivity
 		}
 
-		// Wake at most a few times per the smallest of the
-		// configured windows so timeouts are detected within roughly
-		// 1.25x the configured value in the worst case, while keeping
-		// wakeup overhead negligible.
+		// Pick a wakeup interval as 1/4 of the smallest enabled window
+		// so the worst-case detection latency is roughly 1.25x the
+		// configured value, while keeping wakeup overhead negligible.
+		// A 1s floor is then applied: detection latency therefore
+		// degrades for sub-4-second settings (e.g. a 500ms idle
+		// timeout will detect inside ~1s + the 500ms slack rather
+		// than 125ms). In practice all production-meaningful values
+		// are well above 4 seconds, so this only matters for tests.
 		interval := time.Duration(0)
 		bumpInterval := func(d time.Duration) {
 			if d <= 0 {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -403,13 +403,17 @@ func (s *Server) loadConfig(c *Config, openLog bool) error {
 	s.RelayMaxDuration = time.Duration(c.Proxy.RelayMaxDurationSecs) * time.Second
 	s.TCPKeepAlive = time.Duration(c.Proxy.TCPKeepAliveSecs) * time.Second
 	s.MinThroughputBytes = c.Proxy.MinThroughputBytes
-	s.MinThroughputWindow = time.Duration(c.Proxy.MinThroughputWindowSecs) * time.Second
+	windowSecs := c.Proxy.MinThroughputWindowSecs
+	if windowSecs == 0 {
+		windowSecs = 60
+	}
+	s.MinThroughputWindow = time.Duration(windowSecs) * time.Second
 	graceSecs := c.Proxy.MinThroughputGraceSecs
 	if graceSecs == 0 {
 		// Default the grace period to the window itself: a fresh
 		// connection gets one full window to ramp up before the
 		// floor is enforced.
-		graceSecs = c.Proxy.MinThroughputWindowSecs
+		graceSecs = windowSecs
 	}
 	s.MinThroughputGrace = time.Duration(graceSecs) * time.Second
 	// Reflect the new keepalive and dial-timeout settings on the
@@ -575,11 +579,15 @@ func (s *Server) getPerIPLimitForUpstream(name string) int {
 }
 
 // applyTCPKeepAlive enables TCP keepalive on the given connection if
-// it is a *net.TCPConn and a positive period is provided. Other
-// connection types (e.g. unix sockets) are silently ignored.
+// it is a *net.TCPConn, possibly wrapped by a connection such as
+// *tls.Conn that exposes its underlying connection via NetConn.
+// Other connection types (e.g. unix sockets) are silently ignored.
 func applyTCPKeepAlive(conn net.Conn, period time.Duration) {
 	if period <= 0 {
 		return
+	}
+	if wrapped, ok := conn.(interface{ NetConn() net.Conn }); ok {
+		conn = wrapped.NetConn()
 	}
 	tc, ok := conn.(*net.TCPConn)
 	if !ok {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -209,6 +209,125 @@ func TestClientReadTimeout(t *testing.T) {
 	r.Equal(expected, string(allData))
 }
 
+// TestRelayIdleTimeoutClosesIdleConnection verifies that when
+// RelayIdleTimeout is configured and no data flows in either
+// direction during the bidirectional relay phase, the proxy tears the
+// connection down. This mirrors rsyncd's "timeout" behavior in
+// rsyncd.conf(5).
+func TestRelayIdleTimeoutClosesIdleConnection(t *testing.T) {
+	srv := startServer(t)
+	defer srv.Close()
+	srv.RelayIdleTimeout = 500 * time.Millisecond
+	accessLogPath := setupAccessLog(t, srv)
+
+	r := require.New(t)
+
+	upstreamReady := make(chan struct{})
+	upstreamDone := make(chan struct{})
+
+	fakeRsync := rsync.NewServer(func(conn *rsync.Conn) {
+		defer conn.Close()
+		defer close(upstreamDone)
+
+		_, _, err := doServerHandshake(conn, RsyncdServerVersion)
+		r.NoError(err, "upstream handshake")
+		close(upstreamReady)
+
+		// Stay quiet so the relay phase has no I/O. The proxy must
+		// close us once the idle timeout elapses; ReadAll then
+		// returns with an EOF / closed-connection error.
+		_, _ = io.ReadAll(conn)
+	})
+	fakeRsync.Start()
+	defer fakeRsync.Close()
+
+	srv.modules = map[string][]Target{
+		"fake": {{Upstream: "u1", Addr: fakeRsync.Listener.Addr().String()}},
+	}
+	srv.upstreamQueues = map[string]*queue.Queue{"u1": queue.New(0, 0)}
+
+	rawConn, err := net.Dial("tcp", srv.TCPListener.Addr().String())
+	r.NoError(err)
+	conn := rsync.NewConn(rawConn)
+	defer conn.Close()
+
+	_, err = doClientHandshake(conn, RsyncdServerVersion, "fake")
+	r.NoError(err)
+
+	<-upstreamReady
+
+	start := time.Now()
+	// ReadAll should return shortly after the proxy closes our
+	// connection due to the idle timeout firing on the relay side.
+	_, err = io.ReadAll(conn)
+	r.NoError(err)
+	elapsed := time.Since(start)
+
+	// Allow generous slack: must be at least the configured timeout,
+	// and not pathologically long (e.g. waiting forever).
+	r.GreaterOrEqual(elapsed, srv.RelayIdleTimeout, "should have waited at least the idle timeout")
+	r.Less(elapsed, 5*time.Second, "should not block far beyond the idle timeout")
+
+	select {
+	case <-upstreamDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("upstream connection was not closed after idle timeout")
+	}
+
+	logData, err := os.ReadFile(accessLogPath)
+	r.NoError(err)
+	assert.Contains(t, string(logData), "idle for module fake exceeds")
+}
+
+// TestRelayIdleTimeoutNotTriggeredWhenActive verifies that the idle
+// timeout is reset whenever data flows, so a slow but continuously
+// active stream does not get cut. The fake upstream sends data at an
+// interval well below the idle timeout for several iterations.
+func TestRelayIdleTimeoutNotTriggeredWhenActive(t *testing.T) {
+	srv := startServer(t)
+	defer srv.Close()
+	srv.RelayIdleTimeout = 2 * time.Second
+
+	r := require.New(t)
+
+	const iterations = 5
+	const interval = 200 * time.Millisecond
+
+	fakeRsync := rsync.NewServer(func(conn *rsync.Conn) {
+		defer conn.Close()
+		_, _, err := doServerHandshake(conn, RsyncdServerVersion)
+		r.NoError(err, "upstream handshake")
+
+		for i := 0; i < iterations; i++ {
+			_, err = conn.Write([]byte("data\n"))
+			r.NoError(err, "write data")
+			time.Sleep(interval)
+		}
+	})
+	fakeRsync.Start()
+	defer fakeRsync.Close()
+
+	srv.modules = map[string][]Target{
+		"fake": {{Upstream: "u1", Addr: fakeRsync.Listener.Addr().String()}},
+	}
+	srv.upstreamQueues = map[string]*queue.Queue{"u1": queue.New(0, 0)}
+
+	rawConn, err := net.Dial("tcp", srv.TCPListener.Addr().String())
+	r.NoError(err)
+	conn := rsync.NewConn(rawConn)
+	defer conn.Close()
+
+	_, err = doClientHandshake(conn, RsyncdServerVersion, "fake")
+	r.NoError(err)
+
+	allData, err := io.ReadAll(conn)
+	r.NoError(err)
+
+	expected := strings.Repeat("data\n", iterations)
+	r.Equal(expected, string(allData),
+		"steadily flowing traffic must not be interrupted by the idle timeout")
+}
+
 func TestTLSRsyncListener(t *testing.T) {
 	r := require.New(t)
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1275,6 +1275,7 @@ func TestModuleCountersNormalizeEmptyKeyToUnknown(t *testing.T) {
 	// an empty-string label rendered separately.
 	assert.Equal(t, 1, strings.Count(text, "rsync_proxy_module_completed_connections_total{"))
 }
+
 // TestPerIPCapRejectsConnectionsBeyondLimit verifies that when a
 // per-IP active connection cap is configured for an upstream, a
 // second simultaneous connection from the same client IP to the same

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1256,3 +1256,274 @@ func TestModuleCountersNormalizeEmptyKeyToUnknown(t *testing.T) {
 	// an empty-string label rendered separately.
 	assert.Equal(t, 1, strings.Count(text, "rsync_proxy_module_completed_connections_total{"))
 }
+// TestPerIPCapRejectsConnectionsBeyondLimit verifies that when a
+// per-IP active connection cap is configured for an upstream, a
+// second simultaneous connection from the same client IP to the same
+// upstream is rejected with an @ERROR message, the perIPRejected
+// counter is incremented, and the rejection is reflected in the
+// /metrics output.
+func TestPerIPCapRejectsConnectionsBeyondLimit(t *testing.T) {
+	srv := startServer(t)
+	defer srv.Close()
+	accessLogPath := setupAccessLog(t, srv)
+
+	var release sync.WaitGroup
+	release.Add(1)
+
+	upstream := rsync.NewServer(func(conn *rsync.Conn) {
+		defer conn.Close()
+		_, _, err := doServerHandshake(conn, RsyncdServerVersion)
+		require.NoError(t, err)
+		release.Wait()
+	})
+	upstream.Start()
+	defer upstream.Close()
+
+	srv.reloadLock.Lock()
+	srv.upstreams = []upstreamConfig{
+		{Name: "u1", PerIPMaxActiveConns: 1},
+	}
+	srv.modules = map[string][]Target{
+		"fake": {{Upstream: "u1", Addr: upstream.Listener.Addr().String()}},
+	}
+	srv.upstreamQueues = map[string]*queue.Queue{"u1": queue.New(0, 0)}
+	srv.reloadLock.Unlock()
+
+	// First connection occupies the per-IP slot.
+	c1Raw, err := net.Dial("tcp", srv.TCPListener.Addr().String())
+	require.NoError(t, err)
+	c1 := rsync.NewConn(c1Raw)
+	defer c1.Close()
+	_, err = doClientHandshake(c1, RsyncdServerVersion, "fake")
+	require.NoError(t, err)
+
+	// Second connection from the same IP must be rejected.
+	c2Raw, err := net.Dial("tcp", srv.TCPListener.Addr().String())
+	require.NoError(t, err)
+	c2 := rsync.NewConn(c2Raw)
+	defer c2.Close()
+	_, err = doClientHandshake(c2, RsyncdServerVersion, "fake")
+	require.NoError(t, err)
+
+	body, err := io.ReadAll(c2)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "@ERROR: per-IP connection limit")
+	assert.Contains(t, string(body), "for upstream u1")
+
+	require.Eventually(t, func() bool {
+		return srv.getUpstreamCounters("u1").perIPRejected.Load() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	resp, err := testHTTPClient().Get("http://" + srv.HTTPListener.Addr().String() + "/metrics")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	metricsBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	text := string(metricsBody)
+	assert.Contains(t, text, "# HELP rsync_proxy_per_ip_rejected_total")
+	assert.Contains(t, text, "# TYPE rsync_proxy_per_ip_rejected_total counter")
+	assert.Contains(t, text, "rsync_proxy_per_ip_rejected_total{upstream=\"u1\"} 1\n")
+
+	logData, err := os.ReadFile(accessLogPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(logData), "per-IP cap of 1 reached")
+
+	release.Done()
+}
+
+// TestRelayMaxDurationClosesLongConnection verifies that when
+// RelayMaxDuration is configured, an otherwise-active relay (no idle
+// timeout) is forcibly torn down once it exceeds the configured
+// wall-clock cap.
+func TestRelayMaxDurationClosesLongConnection(t *testing.T) {
+	srv := startServer(t)
+	defer srv.Close()
+	srv.RelayIdleTimeout = 0
+	srv.RelayMaxDuration = 500 * time.Millisecond
+	accessLogPath := setupAccessLog(t, srv)
+
+	r := require.New(t)
+
+	upstreamReady := make(chan struct{})
+	upstreamDone := make(chan struct{})
+
+	fakeRsync := rsync.NewServer(func(conn *rsync.Conn) {
+		defer conn.Close()
+		defer close(upstreamDone)
+
+		_, _, err := doServerHandshake(conn, RsyncdServerVersion)
+		r.NoError(err, "upstream handshake")
+		close(upstreamReady)
+
+		// Stay quiet so the relay phase has no I/O. With idle timeout
+		// disabled, only the max-duration watcher can tear this
+		// connection down.
+		_, _ = io.ReadAll(conn)
+	})
+	fakeRsync.Start()
+	defer fakeRsync.Close()
+
+	srv.modules = map[string][]Target{
+		"fake": {{Upstream: "u1", Addr: fakeRsync.Listener.Addr().String()}},
+	}
+	srv.upstreamQueues = map[string]*queue.Queue{"u1": queue.New(0, 0)}
+
+	rawConn, err := net.Dial("tcp", srv.TCPListener.Addr().String())
+	r.NoError(err)
+	conn := rsync.NewConn(rawConn)
+	defer conn.Close()
+
+	_, err = doClientHandshake(conn, RsyncdServerVersion, "fake")
+	r.NoError(err)
+
+	<-upstreamReady
+
+	start := time.Now()
+	_, err = io.ReadAll(conn)
+	r.NoError(err)
+	elapsed := time.Since(start)
+
+	r.GreaterOrEqual(elapsed, srv.RelayMaxDuration, "should have waited at least the max duration")
+	r.Less(elapsed, 5*time.Second, "should not block far beyond the max duration")
+
+	select {
+	case <-upstreamDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("upstream connection was not closed after max duration")
+	}
+
+	logData, err := os.ReadFile(accessLogPath)
+	r.NoError(err)
+	assert.Contains(t, string(logData), "exceeded max relay duration")
+	assert.Contains(t, string(logData), "for module fake")
+}
+
+// TestApplyTCPKeepAliveOnTCPConn exercises the applyTCPKeepAlive
+// helper end-to-end on a real *net.TCPConn. We cannot portably read
+// SO_KEEPALIVE/TCP_KEEPIDLE back via the standard library, so we
+// verify that the helper does not error and is safe to invoke with
+// zero or negative periods.
+func TestApplyTCPKeepAliveOnTCPConn(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			accepted <- nil
+			return
+		}
+		accepted <- c
+	}()
+
+	clientConn, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	defer clientConn.Close()
+
+	srvConn := <-accepted
+	require.NotNil(t, srvConn)
+	defer srvConn.Close()
+
+	// Should be a no-op for a zero/negative period.
+	applyTCPKeepAlive(srvConn, 0)
+	applyTCPKeepAlive(srvConn, -1*time.Second)
+
+	// Should successfully apply the keepalive on a real *net.TCPConn.
+	applyTCPKeepAlive(srvConn, 45*time.Second)
+	_, ok := srvConn.(*net.TCPConn)
+	assert.True(t, ok, "test sanity: accepted conn should be *net.TCPConn")
+}
+
+// TestLoadConfigPropagatesTCPKeepAliveToDialer verifies that the
+// tcp_keepalive proxy setting is parsed, validated, and propagated to
+// both the Server.TCPKeepAlive field and the underlying dialer used
+// for upstream connections.
+func TestLoadConfigPropagatesTCPKeepAliveToDialer(t *testing.T) {
+	configContent := `
+[proxy]
+listen = "127.0.0.1:0"
+listen_http = "127.0.0.1:0"
+tcp_keepalive = 45
+relay_max_duration = 7200
+per_ip_max_active_connections = 4
+
+[upstreams.u1]
+address = "127.0.0.1:8730"
+modules = ["m1"]
+`
+	srv := New()
+	require.NoError(t, srv.ReadConfig(strings.NewReader(configContent), false))
+
+	assert.Equal(t, 45*time.Second, srv.TCPKeepAlive)
+	assert.Equal(t, 45*time.Second, srv.dialer.KeepAlive)
+	assert.Equal(t, 2*time.Hour, srv.RelayMaxDuration)
+
+	srv.reloadLock.RLock()
+	defer srv.reloadLock.RUnlock()
+	require.Len(t, srv.upstreams, 1)
+	assert.Equal(t, 4, srv.upstreams[0].PerIPMaxActiveConns)
+}
+
+// TestLoadConfigRejectsNegativeTimings verifies that loadConfig
+// rejects negative values for the new connection-control settings.
+func TestLoadConfigRejectsNegativeTimings(t *testing.T) {
+	cases := []struct {
+		name    string
+		config  string
+		wantMsg string
+	}{
+		{
+			name: "relay_max_duration",
+			config: `
+[proxy]
+listen = "127.0.0.1:0"
+listen_http = "127.0.0.1:0"
+relay_max_duration = -1
+
+[upstreams.u1]
+address = "127.0.0.1:8730"
+modules = ["m1"]
+`,
+			wantMsg: "relay_max_duration must be non-negative",
+		},
+		{
+			name: "tcp_keepalive",
+			config: `
+[proxy]
+listen = "127.0.0.1:0"
+listen_http = "127.0.0.1:0"
+tcp_keepalive = -5
+
+[upstreams.u1]
+address = "127.0.0.1:8730"
+modules = ["m1"]
+`,
+			wantMsg: "tcp_keepalive must be non-negative",
+		},
+		{
+			name: "per_ip_max_active_connections",
+			config: `
+[proxy]
+listen = "127.0.0.1:0"
+listen_http = "127.0.0.1:0"
+per_ip_max_active_connections = -2
+
+[upstreams.u1]
+address = "127.0.0.1:8730"
+modules = ["m1"]
+`,
+			wantMsg: "per_ip_max_active_connections must be non-negative",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := New()
+			err := srv.ReadConfig(strings.NewReader(tc.config), false)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantMsg)
+		})
+	}
+}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -244,6 +244,7 @@ func TestRelayIdleTimeoutClosesIdleConnection(t *testing.T) {
 	srv.modules = map[string][]Target{
 		"fake": {{Upstream: "u1", Addr: fakeRsync.Listener.Addr().String()}},
 	}
+	srv.upstreams = []upstreamConfig{{Name: "u1"}}
 	srv.upstreamQueues = map[string]*queue.Queue{"u1": queue.New(0, 0)}
 
 	rawConn, err := net.Dial("tcp", srv.TCPListener.Addr().String())
@@ -277,6 +278,24 @@ func TestRelayIdleTimeoutClosesIdleConnection(t *testing.T) {
 	logData, err := os.ReadFile(accessLogPath)
 	r.NoError(err)
 	assert.Contains(t, string(logData), "idle for module fake exceeds")
+
+	// The watcher must record the termination reason on the
+	// per-upstream counter and surface it via /metrics so that
+	// operators can distinguish a hung-and-killed connection from a
+	// normal completion.
+	r.Eventually(func() bool {
+		return srv.getUpstreamCounters("u1").idleTerminated.Load() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	resp, err := testHTTPClient().Get("http://" + srv.HTTPListener.Addr().String() + "/metrics")
+	r.NoError(err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	r.NoError(err)
+	text := string(body)
+	assert.Contains(t, text, "# HELP rsync_proxy_relay_idle_timeout_terminated_total")
+	assert.Contains(t, text, "# TYPE rsync_proxy_relay_idle_timeout_terminated_total counter")
+	assert.Contains(t, text, "rsync_proxy_relay_idle_timeout_terminated_total{upstream=\"u1\"} 1\n")
 }
 
 // TestRelayIdleTimeoutNotTriggeredWhenActive verifies that the idle
@@ -1366,6 +1385,7 @@ func TestRelayMaxDurationClosesLongConnection(t *testing.T) {
 	srv.modules = map[string][]Target{
 		"fake": {{Upstream: "u1", Addr: fakeRsync.Listener.Addr().String()}},
 	}
+	srv.upstreams = []upstreamConfig{{Name: "u1"}}
 	srv.upstreamQueues = map[string]*queue.Queue{"u1": queue.New(0, 0)}
 
 	rawConn, err := net.Dial("tcp", srv.TCPListener.Addr().String())
@@ -1396,6 +1416,20 @@ func TestRelayMaxDurationClosesLongConnection(t *testing.T) {
 	r.NoError(err)
 	assert.Contains(t, string(logData), "exceeded max relay duration")
 	assert.Contains(t, string(logData), "for module fake")
+
+	r.Eventually(func() bool {
+		return srv.getUpstreamCounters("u1").maxDurationTerminated.Load() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	resp, err := testHTTPClient().Get("http://" + srv.HTTPListener.Addr().String() + "/metrics")
+	r.NoError(err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	r.NoError(err)
+	text := string(body)
+	assert.Contains(t, text, "# HELP rsync_proxy_relay_max_duration_terminated_total")
+	assert.Contains(t, text, "# TYPE rsync_proxy_relay_max_duration_terminated_total counter")
+	assert.Contains(t, text, "rsync_proxy_relay_max_duration_terminated_total{upstream=\"u1\"} 1\n")
 }
 
 // TestApplyTCPKeepAliveOnTCPConn exercises the applyTCPKeepAlive
@@ -1516,6 +1550,62 @@ modules = ["m1"]
 `,
 			wantMsg: "per_ip_max_active_connections must be non-negative",
 		},
+		{
+			name: "dial_timeout",
+			config: `
+[proxy]
+listen = "127.0.0.1:0"
+listen_http = "127.0.0.1:0"
+dial_timeout = -1
+
+[upstreams.u1]
+address = "127.0.0.1:8730"
+modules = ["m1"]
+`,
+			wantMsg: "dial_timeout must be non-negative",
+		},
+		{
+			name: "min_throughput_bytes",
+			config: `
+[proxy]
+listen = "127.0.0.1:0"
+listen_http = "127.0.0.1:0"
+min_throughput_bytes = -1
+
+[upstreams.u1]
+address = "127.0.0.1:8730"
+modules = ["m1"]
+`,
+			wantMsg: "min_throughput_bytes must be non-negative",
+		},
+		{
+			name: "min_throughput_window",
+			config: `
+[proxy]
+listen = "127.0.0.1:0"
+listen_http = "127.0.0.1:0"
+min_throughput_window = -1
+
+[upstreams.u1]
+address = "127.0.0.1:8730"
+modules = ["m1"]
+`,
+			wantMsg: "min_throughput_window must be non-negative",
+		},
+		{
+			name: "min_throughput_grace",
+			config: `
+[proxy]
+listen = "127.0.0.1:0"
+listen_http = "127.0.0.1:0"
+min_throughput_grace = -1
+
+[upstreams.u1]
+address = "127.0.0.1:8730"
+modules = ["m1"]
+`,
+			wantMsg: "min_throughput_grace must be non-negative",
+		},
 	}
 
 	for _, tc := range cases {
@@ -1526,4 +1616,144 @@ modules = ["m1"]
 			assert.Contains(t, err.Error(), tc.wantMsg)
 		})
 	}
+}
+
+// TestThroughputFloorTerminatesSlowConnection verifies that when a
+// throughput floor is configured, an otherwise-active relay (no idle
+// timeout, no max-duration) which transfers fewer than MinThroughputBytes
+// per MinThroughputWindow is forcibly torn down once the grace period
+// elapses, the per-upstream counter is incremented, and the rejection
+// is reflected in /metrics and the access log.
+func TestThroughputFloorTerminatesSlowConnection(t *testing.T) {
+	srv := startServer(t)
+	defer srv.Close()
+	srv.RelayIdleTimeout = 0
+	srv.RelayMaxDuration = 0
+	// Demand effectively infeasible throughput in a 200ms window so
+	// the floor always trips. Grace = 0 so the very first sample
+	// after the window elapses is enough.
+	srv.MinThroughputBytes = 1 << 30
+	srv.MinThroughputWindow = 200 * time.Millisecond
+	srv.MinThroughputGrace = 0
+	accessLogPath := setupAccessLog(t, srv)
+
+	r := require.New(t)
+
+	upstreamReady := make(chan struct{})
+	upstreamDone := make(chan struct{})
+
+	fakeRsync := rsync.NewServer(func(conn *rsync.Conn) {
+		defer conn.Close()
+		defer close(upstreamDone)
+
+		_, _, err := doServerHandshake(conn, RsyncdServerVersion)
+		r.NoError(err, "upstream handshake")
+		close(upstreamReady)
+
+		// Stay quiet so the relay phase has effectively zero throughput.
+		_, _ = io.ReadAll(conn)
+	})
+	fakeRsync.Start()
+	defer fakeRsync.Close()
+
+	srv.modules = map[string][]Target{
+		"fake": {{Upstream: "u1", Addr: fakeRsync.Listener.Addr().String()}},
+	}
+	srv.upstreams = []upstreamConfig{{Name: "u1"}}
+	srv.upstreamQueues = map[string]*queue.Queue{"u1": queue.New(0, 0)}
+
+	rawConn, err := net.Dial("tcp", srv.TCPListener.Addr().String())
+	r.NoError(err)
+	conn := rsync.NewConn(rawConn)
+	defer conn.Close()
+
+	_, err = doClientHandshake(conn, RsyncdServerVersion, "fake")
+	r.NoError(err)
+
+	<-upstreamReady
+
+	start := time.Now()
+	_, err = io.ReadAll(conn)
+	r.NoError(err)
+	elapsed := time.Since(start)
+
+	r.GreaterOrEqual(elapsed, srv.MinThroughputWindow,
+		"should have waited at least one throughput window before tearing down")
+	r.Less(elapsed, 5*time.Second, "should not block far beyond the throughput window")
+
+	select {
+	case <-upstreamDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("upstream connection was not closed after throughput floor trip")
+	}
+
+	r.Eventually(func() bool {
+		return srv.getUpstreamCounters("u1").throughputFloorTerminated.Load() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	resp, err := testHTTPClient().Get("http://" + srv.HTTPListener.Addr().String() + "/metrics")
+	r.NoError(err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	r.NoError(err)
+	text := string(body)
+	assert.Contains(t, text, "# HELP rsync_proxy_throughput_floor_terminated_total")
+	assert.Contains(t, text, "# TYPE rsync_proxy_throughput_floor_terminated_total counter")
+	assert.Contains(t, text, "rsync_proxy_throughput_floor_terminated_total{upstream=\"u1\"} 1\n")
+
+	logData, err := os.ReadFile(accessLogPath)
+	r.NoError(err)
+	assert.Contains(t, string(logData), "below throughput floor")
+	assert.Contains(t, string(logData), "for module fake")
+}
+
+// TestLoadConfigPropagatesDialTimeoutAndThroughputSettings verifies
+// that dial_timeout and the min_throughput_* settings are parsed,
+// validated, and propagated into the dialer and Server fields. It also
+// verifies that an unset min_throughput_grace falls back to the
+// configured min_throughput_window, mirroring the documented default.
+func TestLoadConfigPropagatesDialTimeoutAndThroughputSettings(t *testing.T) {
+	t.Run("explicit grace", func(t *testing.T) {
+		configContent := `
+[proxy]
+listen = "127.0.0.1:0"
+listen_http = "127.0.0.1:0"
+dial_timeout = 5
+min_throughput_bytes = 65536
+min_throughput_window = 60
+min_throughput_grace = 30
+
+[upstreams.u1]
+address = "127.0.0.1:8730"
+modules = ["m1"]
+`
+		srv := New()
+		require.NoError(t, srv.ReadConfig(strings.NewReader(configContent), false))
+
+		assert.Equal(t, 5*time.Second, srv.dialer.Timeout)
+		assert.Equal(t, int64(65536), srv.MinThroughputBytes)
+		assert.Equal(t, 60*time.Second, srv.MinThroughputWindow)
+		assert.Equal(t, 30*time.Second, srv.MinThroughputGrace)
+	})
+
+	t.Run("grace defaults to window", func(t *testing.T) {
+		configContent := `
+[proxy]
+listen = "127.0.0.1:0"
+listen_http = "127.0.0.1:0"
+min_throughput_bytes = 1024
+min_throughput_window = 90
+
+[upstreams.u1]
+address = "127.0.0.1:8730"
+modules = ["m1"]
+`
+		srv := New()
+		require.NoError(t, srv.ReadConfig(strings.NewReader(configContent), false))
+
+		assert.Equal(t, int64(1024), srv.MinThroughputBytes)
+		assert.Equal(t, 90*time.Second, srv.MinThroughputWindow)
+		assert.Equal(t, 90*time.Second, srv.MinThroughputGrace,
+			"unset min_throughput_grace must default to min_throughput_window")
+	})
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1469,6 +1469,12 @@ func TestApplyTCPKeepAliveOnTCPConn(t *testing.T) {
 	applyTCPKeepAlive(srvConn, 45*time.Second)
 	_, ok := srvConn.(*net.TCPConn)
 	assert.True(t, ok, "test sanity: accepted conn should be *net.TCPConn")
+
+	// TLS listeners pass a *tls.Conn to handleConn. Ensure the helper
+	// reaches the underlying TCP connection without requiring a TLS
+	// handshake.
+	tlsConn := tls.Server(srvConn, &tls.Config{})
+	applyTCPKeepAlive(tlsConn, 45*time.Second)
 }
 
 // TestLoadConfigPropagatesTCPKeepAliveToDialer verifies that the
@@ -1756,5 +1762,24 @@ modules = ["m1"]
 		assert.Equal(t, 90*time.Second, srv.MinThroughputWindow)
 		assert.Equal(t, 90*time.Second, srv.MinThroughputGrace,
 			"unset min_throughput_grace must default to min_throughput_window")
+	})
+
+	t.Run("window defaults to sixty seconds", func(t *testing.T) {
+		configContent := `
+[proxy]
+listen = "127.0.0.1:0"
+listen_http = "127.0.0.1:0"
+min_throughput_bytes = 1024
+
+[upstreams.u1]
+address = "127.0.0.1:8730"
+modules = ["m1"]
+`
+		srv := New()
+		require.NoError(t, srv.ReadConfig(strings.NewReader(configContent), false))
+
+		assert.Equal(t, int64(1024), srv.MinThroughputBytes)
+		assert.Equal(t, 60*time.Second, srv.MinThroughputWindow)
+		assert.Equal(t, 60*time.Second, srv.MinThroughputGrace)
 	})
 }


### PR DESCRIPTION
## Summary

This PR adds a comprehensive set of connection-lifecycle protection mechanisms to defend rsync-proxy against slow-loris-style abuse, half-open / hung connections, dead upstreams, and single-IP exhaustion. All settings default to off (0), preserving existing behavior, and can be enabled per-deployment via `[proxy]` config.

The new metrics that go alongside these features make it possible to *observe* what's happening in production and *tune* the limits with evidence rather than guesses.

Also bundled: per-field configuration documentation in README, a ready-to-import Grafana dashboard JSON, and `config.example.toml` annotations with recommended starting values for each knob.

The commits are organized so each major piece can be reviewed independently:

1. **`feat: add relay-phase idle timeout`** — mirrors `rsyncd.conf` `timeout =` semantics for the bidirectional relay phase.
2. **`feat: add connection controls (TCP keepalive, per-IP cap, relay max duration)`** — three independent knobs.
3. **`feat: add dial timeout, throughput floor, and termination-cause counters`** — defensive dial timeout, slow-throughput detection, and per-cause counters that distinguish watcher-killed from natural connection completions.
4. A few style / review-fix follow-ups.
5. **Documentation & Grafana dashboard**: `config.example.toml` recommended values, README with per-field tables for all 23 config items, and a pre-built Grafana dashboard (`grafana/dashboard.json`) covering all metrics introduced since #34.

## Motivation

Production experience operating this proxy in front of a busy public mirror surfaced several pain points that the existing `max_active_connections` / `max_queued_connections` knobs cannot address:

- Connections that sit idle indefinitely (clients suspended, NAT entries expired, network half-open) hold a slot until the OS TCP keepalive kicks in (~2 hours by default).
- Single-IP misuse — one client opening many parallel rsync connections to the same upstream — easily fills the active-conn pool and causes legitimate users to hit the queue.
- "Slow loris" style abuse — clients that read at byte-per-minute rates — keep slots locked for hours without ever triggering an idle timeout.
- A dead upstream causes every new dial to wait ~75 s on kernel SYN retries before failing, amplifying the impact during outages.
- When a connection ends, there was no way to tell from metrics whether it ended naturally or was force-closed by the proxy, making it hard to tune the new timeouts safely.

## What's added

### `[proxy]` configuration knobs

| Setting | Type | Default | Behavior |
| --- | --- | --- | --- |
| `relay_idle_timeout` | int (s) | `0` | Close the relay if neither direction has any I/O for the given duration. Mirrors `rsyncd.conf timeout =` semantics. `0` disables. |
| `relay_max_duration` | int (s) | `0` | Hard ceiling on a single relay's lifetime. `0` disables. |
| `tcp_keepalive` | int (s) | `0` | TCP keepalive period applied to both accepted client connections and dialed upstream connections. `0` keeps OS defaults. |
| `dial_timeout` | int (s) | `0` | `net.Dialer.Timeout` used when dialing upstreams. `0` keeps OS SYN-retry defaults (~75 s). |
| `per_ip_max_active_connections` | int | `0` | Proxy-wide default cap on simultaneous relayed connections per (upstream, client IP). `0` disables. Per-upstream override available. |
| `min_throughput_bytes` | int64 | `0` | Together with `min_throughput_window`, defines a floor: if a connection moves fewer than this many bytes (sent + received) over any window after the grace period, it is closed. `0` disables. |
| `min_throughput_window` | int (s) | `60` | Sliding window length for the throughput floor check. Inactive unless `min_throughput_bytes > 0`. |
| `min_throughput_grace` | int (s) | `=window` | Grace period after relay start during which the throughput floor is not enforced. Defaults to the window value if unset. Useful for letting the rsync file-list phase complete on very large modules without triggering the floor. |

### `[upstreams.<name>]` override

| Setting | Type | Default | Behavior |
| --- | --- | --- | --- |
| `per_ip_max_active_connections` | int | inherits proxy-wide | Per-upstream override of the cap. `0` falls back to the proxy-wide setting; if both are `0` there is no cap. |

### New Prometheus metrics

| Metric | Type | Labels | Increments when |
| --- | --- | --- | --- |
| `rsync_proxy_per_ip_rejected_total` | counter | `upstream` | A connection is rejected because the (upstream, IP) cap was already at limit. |
| `rsync_proxy_relay_idle_timeout_terminated_total` | counter | `upstream` | The relay watcher closed a connection due to `relay_idle_timeout`. |
| `rsync_proxy_relay_max_duration_terminated_total` | counter | `upstream` | The relay watcher closed a connection due to `relay_max_duration`. |
| `rsync_proxy_throughput_floor_terminated_total` | counter | `upstream` | The relay watcher closed a connection due to falling below `min_throughput_bytes` over a window. |

These three `*_terminated_total` counters are deliberately separate from the existing `completed_connections_total` so operators can distinguish *natural* completions from *enforced* terminations and tune limits without flying blind.

### Grafana dashboard

`grafana/dashboard.json` provides 29 panels covering connection lifecycle, per-module traffic, queue health, failure breakdown, termination causes, and Go runtime — all using the Prometheus metrics from #34, #36, and this PR. Import-ready with a `DS_PROMETHEUS` variable.

## Implementation notes

### Watcher consolidation

The three relay-phase watchers (idle, max-duration, throughput floor) are implemented as a single goroutine with one `time.Ticker`. The tick interval is computed as `min(idle/4, maxDuration/4, window/4)` over the enabled checks, with a 1 s lower bound. The watcher is only started if at least one check is enabled, so connections with all checks disabled have zero overhead beyond what's already there.

### Race-safety with config reload

All new timing fields are read through helpers that take `reloadLock.RLock()` (`getRelayTimings`, `getTCPKeepAlive`, `getDialer`, `getPerIPLimitForUpstream`). `getRelayTimings` returns a `relayTimings` struct snapshot to keep all six values mutually consistent within one tick. `getDialer` returns a copy of `s.dialer` so that the dialer's `Timeout` and `KeepAlive` can be updated by reload without racing with in-flight dials.

### Per-IP counters

Stored in a `sync.Map` keyed by `{upstream, ip}` with `*atomic.Int64` values. Lazy-initialized on first use; entries are *not* removed when the count returns to zero (kept simple — the working set is bounded by `len(upstreams) × distinct active IPs`, which is small in practice).

The check is CAS-style: increment first, decrement+reject if over limit, otherwise `defer counter.Add(-1)`. This avoids any TOCTOU race between checking and reserving the slot.

### TCP keepalive

Applied via a small helper `applyTCPKeepAlive(conn, period)` that no-ops on non-TCP connections (e.g., unix sockets) and on `period <= 0`. Called both on the accepted client connection in `handleConn` and on the dialed upstream connection after `relay()` connects.

### Throughput floor

The watcher samples `info.SentBytes + info.ReceivedBytes` (already tracked atomically by the `countingReader`). On each tick after the grace period, it checks whether the per-window delta has fallen below the configured byte floor. The grace period is critical: it allows the rsync file-list / generator phase to complete on modules with millions of small files without false positives. The grace defaults to the window length, which is enough for most modules; operators with very large modules (e.g. `debian-archive`, `opensuse-source-vault`) should set it higher.

### Why throughput floor and idle timeout are both needed

A "slow loris" style client that sends one byte per second will *never* trigger an idle timeout (there's always recent activity), but will trivially trip a sub-MiB-per-minute throughput floor. Conversely, a fully suspended client triggers idle quickly without needing the throughput check.

## Backward compatibility

All new knobs default to `0` and the new behaviors are off unless explicitly enabled. Existing deployments see no behavioral change.

The new counters all have `upstream` labels matching the existing PR #34 convention (config name, not `IP:port`). They are pure additions — no existing series are renamed or removed.

## Testing

Each commit ships with focused unit tests:

- `TestRelayIdleTimeoutClosesIdleConnection` / `TestRelayIdleTimeoutNotTriggeredWhenActive`
- `TestPerIPCapRejectsConnectionsBeyondLimit`
- `TestRelayMaxDurationClosesLongConnection`
- `TestApplyTCPKeepAliveOnTCPConn`
- `TestLoadConfigPropagatesTCPKeepAliveToDialer`
- `TestLoadConfigRejectsNegativeTimings` (table-driven)
- `TestThroughputFloorTerminatesSlowConnection`
- `TestLoadConfigPropagatesDialTimeoutAndThroughputSettings` (incl. grace-defaults-to-window)
- `TestLoadConfigRejectsNegativeNewSettings`
- Tests assert both the underlying counters (`upstreamCounters.*Terminated`) and the rendered `/metrics` output.

`go vet`, `go build`, `go test -race ./...`, and `golangci-lint run` all pass.

## Production validation

This change set has been running on a busy public rsync mirror for several weeks. The new counters surfaced previously-invisible problems immediately — most notably a sustained rate of queue-full rejections during peaks and individual relays that had stayed open for multiple days at a time — and the protection knobs brought the situation under control.